### PR TITLE
Added NoPossibleKeys to KeyWrap

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -196,10 +196,13 @@ func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) 
 		if b64Annotation != "" {
 			keywrapper := GetKeyWrapper(scheme)
 
-			if len(keywrapper.GetPrivateKeys(dc.Parameters)) == 0 {
+			if keywrapper.NoPossibleKeys(dc.Parameters) {
 				continue
 			}
-			privKeyGiven = true
+
+			if len(keywrapper.GetPrivateKeys(dc.Parameters)) > 0 {
+				privKeyGiven = true
+			}
 
 			optsData, err := preUnwrapKey(keywrapper, dc, b64Annotation)
 			if err != nil {

--- a/keywrap/jwe/keywrapper_jwe.go
+++ b/keywrap/jwe/keywrapper_jwe.go
@@ -91,6 +91,10 @@ func (kw *jweKeyWrapper) UnwrapKey(dc *config.DecryptConfig, jweString []byte) (
 	return nil, errors.New("JWE: No suitable private key found for decryption")
 }
 
+func (kw *jweKeyWrapper) NoPossibleKeys(dcparameters map[string][][]byte) bool {
+	return len(kw.GetPrivateKeys(dcparameters)) == 0
+}
+
 func (kw *jweKeyWrapper) GetPrivateKeys(dcparameters map[string][][]byte) [][]byte {
 	return dcparameters["privkeys"]
 }

--- a/keywrap/keywrap.go
+++ b/keywrap/keywrap.go
@@ -26,15 +26,23 @@ type KeyWrapper interface {
 	WrapKeys(ec *config.EncryptConfig, optsData []byte) ([]byte, error)
 	UnwrapKey(dc *config.DecryptConfig, annotation []byte) ([]byte, error)
 	GetAnnotationID() string
+
+	// NoPossibleKeys returns true if there is no possibility of performing
+	// decryption for parameters provided.
+	NoPossibleKeys(dcparameters map[string][][]byte) bool
+
 	// GetPrivateKeys (optional) gets the array of private keys. It is an optional implementation
 	// as in some key services, a private key may not be exportable (i.e. HSM)
+	// If not implemented, return nil
 	GetPrivateKeys(dcparameters map[string][][]byte) [][]byte
 
 	// GetKeyIdsFromPacket (optional) gets a list of key IDs. This is optional as some encryption
 	// schemes may not have a notion of key IDs
+	// If not implemented, return the nil slice
 	GetKeyIdsFromPacket(packet string) ([]uint64, error)
 
 	// GetRecipients (optional) gets a list of recipients. It is optional due to the validity of
 	// recipients in a particular encryptiong scheme
+	// If not implemented, return the nil slice
 	GetRecipients(packet string) ([]string, error)
 }

--- a/keywrap/pgp/keywrapper_gpg.go
+++ b/keywrap/pgp/keywrapper_gpg.go
@@ -191,6 +191,10 @@ func (kw *gpgKeyWrapper) GetRecipients(b64pgpPackets string) ([]string, error) {
 	return array, nil
 }
 
+func (kw *gpgKeyWrapper) NoPossibleKeys(dcparameters map[string][][]byte) bool {
+	return len(kw.GetPrivateKeys(dcparameters)) == 0
+}
+
 func (kw *gpgKeyWrapper) GetPrivateKeys(dcparameters map[string][][]byte) [][]byte {
 	return dcparameters["gpg-privatekeys"]
 }

--- a/keywrap/pkcs7/keywrapper_pkcs7.go
+++ b/keywrap/pkcs7/keywrapper_pkcs7.go
@@ -70,6 +70,10 @@ func collectX509s(x509s [][]byte) ([]*x509.Certificate, error) {
 	return x509Certs, nil
 }
 
+func (kw *pkcs7KeyWrapper) NoPossibleKeys(dcparameters map[string][][]byte) bool {
+	return len(kw.GetPrivateKeys(dcparameters)) == 0
+}
+
 func (kw *pkcs7KeyWrapper) GetPrivateKeys(dcparameters map[string][][]byte) [][]byte {
 	return dcparameters["privkeys"]
 }


### PR DESCRIPTION
This PR ensures that `GetPrivateKeys` is optional in a keywrapper implementation.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>