### PR TITLE
[DNM for now, requires resolution with PR#19] support for pkcs#11

### DIFF
--- a/config/constructors.go
+++ b/config/constructors.go
@@ -71,6 +71,27 @@ func EncryptWithGpg(gpgRecipients [][]byte, gpgPubRingFile []byte) (CryptoConfig
 }
 
 // EncryptWithPkcs11 returns a CryptoConfig to encrypt with configured PKCS11 parameters
+//
+// WARNING: will encrypt with modules
+//
+// Encrypt Config, As an example:
+//
+//  modulePath := "/usr/local/lib/softhsm/libsofthsm2.so"
+//	modulePin := "1234"
+//  modules := [][]byte{}
+//  pins := [][]byte{}
+//  modules = append(modules, []byte(modulePath))
+//  pins = append(pins, []byte(modulePin))
+//
+//  validPkcs11Ccs := &config.CryptoConfig{
+//		EncryptConfig: &config.EncryptConfig{
+//			Parameters: map[string][][]byte{
+//				"modules": modules,
+//				"pins":    pins,
+//			},
+//		},
+//		DecryptConfig: &DecryptConfig{},
+//	}
 func EncryptWithPkcs11(modules [][]byte, pins [][]byte) (CryptoConfig, error) {
 	if len(modules) != len(pins) {
 		return CryptoConfig{}, errors.New("Length of modules should match length of pins")

--- a/config/constructors.go
+++ b/config/constructors.go
@@ -70,6 +70,24 @@ func EncryptWithGpg(gpgRecipients [][]byte, gpgPubRingFile []byte) (CryptoConfig
 	}, nil
 }
 
+func EncryptWithPkcs11(modules [][]byte) (CryptoConfig, error) {
+	if len(modules) != 2 {
+		return CryptoConfig{}, nil
+	}
+	dc := DecryptConfig{}
+	ep := map[string][][]byte{
+		"modules": {modules[0]},
+		"pin":     {modules[1]},
+	}
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}, nil
+}
+
 // DecryptWithPrivKeys returns a CryptoConfig to decrypt with configured private keys
 func DecryptWithPrivKeys(privKeys [][]byte, privKeysPasswords [][]byte) (CryptoConfig, error) {
 	if len(privKeys) != len(privKeysPasswords) {
@@ -124,6 +142,24 @@ func DecryptWithGpgPrivKeys(gpgPrivKeys, gpgPrivKeysPwds [][]byte) (CryptoConfig
 
 	ep := map[string][][]byte{}
 
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}, nil
+}
+
+// DecryptWithPkcs11 returns a CryptoConfig to decrypt with configured pkcs11 modules
+func DecryptWithPkcs11(modules [][]byte) (CryptoConfig, error) {
+	dc := DecryptConfig{
+		Parameters: map[string][][]byte{
+			"modules": {modules[0]},
+			"pin":     {modules[1]},
+		},
+	}
+	ep := map[string][][]byte{}
 	return CryptoConfig{
 		EncryptConfig: &EncryptConfig{
 			Parameters:    ep,

--- a/config/constructors.go
+++ b/config/constructors.go
@@ -70,15 +70,23 @@ func EncryptWithGpg(gpgRecipients [][]byte, gpgPubRingFile []byte) (CryptoConfig
 	}, nil
 }
 
-func EncryptWithPkcs11(modules [][]byte) (CryptoConfig, error) {
-	if len(modules) != 2 {
-		return CryptoConfig{}, nil
+// EncryptWithPkcs11 returns a CryptoConfig to encrypt with configured PKCS11 parameters
+func EncryptWithPkcs11(modules [][]byte, pins [][]byte) (CryptoConfig, error) {
+	if len(modules) != len(pins) {
+		return CryptoConfig{}, errors.New("Length of modules should match length of pins")
 	}
+
+	// TODO: experimental, just support single module
+	if len(modules) != 1 {
+		return CryptoConfig{}, errors.New("experimental, just support single module")
+	}
+
 	dc := DecryptConfig{}
 	ep := map[string][][]byte{
-		"modules": {modules[0]},
-		"pin":     {modules[1]},
+		"modules": modules,
+		"pins":    pins,
 	}
+
 	return CryptoConfig{
 		EncryptConfig: &EncryptConfig{
 			Parameters:    ep,
@@ -152,11 +160,11 @@ func DecryptWithGpgPrivKeys(gpgPrivKeys, gpgPrivKeysPwds [][]byte) (CryptoConfig
 }
 
 // DecryptWithPkcs11 returns a CryptoConfig to decrypt with configured pkcs11 modules
-func DecryptWithPkcs11(modules [][]byte) (CryptoConfig, error) {
+func DecryptWithPkcs11(modules [][]byte, pins [][]byte) (CryptoConfig, error) {
 	dc := DecryptConfig{
 		Parameters: map[string][][]byte{
-			"modules": {modules[0]},
-			"pin":     {modules[1]},
+			"modules": modules,
+			"pins":    pins,
 		},
 	}
 	ep := map[string][][]byte{}

--- a/encryption.go
+++ b/encryption.go
@@ -19,6 +19,7 @@ package ocicrypt
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/containers/ocicrypt/keywrap/pkcs11"
 	"io"
 	"strings"
 
@@ -43,6 +44,7 @@ func init() {
 	RegisterKeyWrapper("pgp", pgp.NewKeyWrapper())
 	RegisterKeyWrapper("jwe", jwe.NewKeyWrapper())
 	RegisterKeyWrapper("pkcs7", pkcs7.NewKeyWrapper())
+	RegisterKeyWrapper("pkcs11", pkcs11.NewKeyWrapper())
 }
 
 var keyWrappers map[string]keywrap.KeyWrapper

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/miekg/pkcs11 v1.0.3
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/miekg/pkcs11 v1.0.3 h1:iMwmD7I5225wv84WxIG/bmxz9AXjWvTWIbM/TYHvWtw=
+github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=

--- a/keywrap/pkcs11/keywrapper_pkcs11.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The ocicrypt Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package pkcs11
 
 import (
@@ -197,8 +213,8 @@ func loginDevice(modules [][]byte, pins [][]byte) (ctx *pkcs11.Ctx, session pkcs
 }
 
 func closeModule(ctx *pkcs11.Ctx, session pkcs11.SessionHandle) {
-	defer ctx.CloseSession(session)
 	defer ctx.Logout(session)
+	defer ctx.CloseSession(session)
 	defer ctx.Destroy()
 	defer ctx.Finalize()
 }

--- a/keywrap/pkcs11/keywrapper_pkcs11.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11.go
@@ -149,7 +149,7 @@ func generateRSAKeyPair(p *pkcs11.Ctx, session pkcs11.SessionHandle, tokenLabel 
 	return pbk, pvk
 }
 
-// loginDevice login Device and use the slot[0]
+// loginDevice login Device
 func loginDevice(modules [][]byte, pins [][]byte) (ctx *pkcs11.Ctx, session pkcs11.SessionHandle, err error) {
 	if len(pins) == 0 {
 		return nil, 0, errors.New("Need input module pin")
@@ -162,11 +162,11 @@ func loginDevice(modules [][]byte, pins [][]byte) (ctx *pkcs11.Ctx, session pkcs
 	}
 	module := string(modules[0])
 	module = strings.TrimSpace(module)
-	if module == "" {
+	ctx = pkcs11.New(module)
+	if ctx == nil {
 		return nil, 0, errors.New("Please check Module path, input is: " + module)
 	}
 
-	ctx = pkcs11.New(module)
 	err = ctx.Initialize()
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "Device Initialize failed")

--- a/keywrap/pkcs11/keywrapper_pkcs11.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11.go
@@ -1,0 +1,204 @@
+package pkcs11
+
+import (
+	"fmt"
+	"github.com/containers/ocicrypt/config"
+	"github.com/containers/ocicrypt/keywrap"
+	"github.com/miekg/pkcs11"
+	"github.com/pkg/errors"
+	"strings"
+)
+
+var (
+	KeyLabel   = "imgenc"
+	OAEPParams = &pkcs11.OAEPParams{
+		HashAlg:    pkcs11.CKM_SHA_1,
+		MGF:        pkcs11.CKG_MGF1_SHA1,
+		SourceType: pkcs11.CKZ_DATA_SPECIFIED,
+		SourceData: nil,
+	}
+)
+
+type pkcs11KeyWrapper struct {
+}
+
+func NewKeyWrapper() keywrap.KeyWrapper {
+	return &pkcs11KeyWrapper{}
+}
+
+func (kw pkcs11KeyWrapper) GetAnnotationID() string {
+	return "org.opencontainers.image.enc.keys.pkcs11"
+}
+
+func (kw pkcs11KeyWrapper) WrapKeys(ec *config.EncryptConfig, optsData []byte) ([]byte, error) {
+	// no recipients
+	if len(ec.Parameters["modules"]) == 0 || len(ec.Parameters["pin"]) == 0 {
+		return nil, nil
+	}
+	p11ctx, session, err := loginDevice(ec.Parameters["modules"], ec.Parameters["pin"])
+	if err != nil {
+		return nil, err
+	}
+
+	pub, _ := getRSA(KeyLabel, p11ctx, session)
+
+	err = p11ctx.EncryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_OAEP, OAEPParams)}, pub)
+	encrypt, err := p11ctx.Encrypt(session, optsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "Encrypt with Module failed")
+	}
+
+	closeModule(p11ctx, session)
+	return encrypt, nil
+}
+
+func (kw pkcs11KeyWrapper) UnwrapKey(dc *config.DecryptConfig, encrypted []byte) (plain []byte, err error) {
+	p11ctx, session, err := loginDevice(dc.Parameters["modules"], dc.Parameters["pin"])
+
+	priv, err := findObject(p11ctx, session, pkcs11.CKO_PRIVATE_KEY, KeyLabel)
+
+	err = p11ctx.DecryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_OAEP, OAEPParams)}, priv)
+	if err != nil {
+		return nil, errors.Wrap(err, "Decrypt init failed")
+	}
+	plain, err = p11ctx.Decrypt(session, encrypted)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Decrypt failed")
+	}
+
+	closeModule(p11ctx, session)
+	return
+}
+
+func (kw pkcs11KeyWrapper) NoPossibleKeys(dcparameters map[string][][]byte) bool {
+	return len(kw.GetPrivateKeys(dcparameters)) == 0
+}
+
+// GetPrivateKeys return private key handle
+func (kw pkcs11KeyWrapper) GetPrivateKeys(dcparameters map[string][][]byte) [][]byte {
+	return dcparameters["modules"]
+}
+
+// GetKeyIdsFromWrappedKeys converts the base64 encoded Packet to uint64 keyIds;
+// We cannot do this with pkcs11
+func (kw pkcs11KeyWrapper) GetKeyIdsFromPacket(packet string) ([]uint64, error) {
+	return nil, nil
+}
+
+// GetRecipients converts the wrappedKeys to an array of recipients
+// We cannot do this with pkcs11
+func (kw pkcs11KeyWrapper) GetRecipients(packet string) ([]string, error) {
+	return []string{"[pkcs11]"}, nil
+}
+
+// getRSA generate a rsa key if it doesn't exist
+func getRSA(label string, p *pkcs11.Ctx, sh pkcs11.SessionHandle) (pub, priv pkcs11.ObjectHandle) {
+	pub, err := findObject(p, sh, pkcs11.CKO_PUBLIC_KEY, label)
+	if err != nil {
+		pub, priv = generateRSAKeyPair(p, sh, label, true)
+	}
+	return
+}
+
+func findObject(p *pkcs11.Ctx, sh pkcs11.SessionHandle, class uint, label string) (pkcs11.ObjectHandle, error) {
+	template := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+	}
+	if err := p.FindObjectsInit(sh, template); err != nil {
+		return 0, errors.Wrap(err, "FindObjectsInit")
+	}
+	obj, _, err := p.FindObjects(sh, 1)
+	if err != nil {
+		return 0, errors.Wrap(err, "FindObjects")
+	}
+	if err := p.FindObjectsFinal(sh); err != nil {
+		return 0, errors.Wrap(err, "FindObjectsFinal")
+	}
+	if len(obj) > 0 {
+		return obj[0], nil
+	}
+	return 0, errors.New("Not Found Object")
+}
+
+func generateRSAKeyPair(p *pkcs11.Ctx, session pkcs11.SessionHandle, tokenLabel string, tokenPersistent bool) (pkcs11.ObjectHandle, pkcs11.ObjectHandle) {
+	publicKeyTemplate := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_RSA),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, tokenPersistent),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+		pkcs11.NewAttribute(pkcs11.CKA_PUBLIC_EXPONENT, []byte{1, 0, 1}),
+		pkcs11.NewAttribute(pkcs11.CKA_MODULUS_BITS, 2048),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, tokenLabel),
+	}
+	privateKeyTemplate := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, tokenPersistent),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, tokenLabel),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, true),
+	}
+	pbk, pvk, e := p.GenerateKeyPair(session,
+		[]*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_KEY_PAIR_GEN, nil)},
+		publicKeyTemplate, privateKeyTemplate)
+	if e != nil {
+		fmt.Printf("failed to generate keypair: %s\n", e.Error())
+	}
+
+	return pbk, pvk
+}
+
+// loginDevice login Device and use the slot[0]
+func loginDevice(modules [][]byte, pins [][]byte) (ctx *pkcs11.Ctx, session pkcs11.SessionHandle, err error) {
+	if len(pins) == 0 {
+		return nil, 0, errors.New("Need input module pin")
+	}
+	pin := string(pins[0])
+	pin = strings.TrimSpace(pin)
+
+	if len(modules) > 1 {
+		return nil, 0, errors.New("Just support *one* module")
+	}
+	module := string(modules[0])
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return nil, 0, errors.New("Please check Module path, input is: " + module)
+	}
+
+	ctx = pkcs11.New(module)
+	err = ctx.Initialize()
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "Device Initialize failed")
+	}
+	slots, err := ctx.GetSlotList(true)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "Get Slots failed")
+	}
+
+	var logged = false
+	if len(slots) > 0 {
+		for _, slot := range slots {
+			session, err = ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+			if err != nil {
+				return nil, 0, errors.Wrap(err, "Open Session failed")
+			}
+			err = ctx.Login(session, pkcs11.CKU_USER, pin)
+			if err == nil {
+				logged = true
+				break
+			}
+		}
+	}
+	if !logged {
+		return ctx, 0, errors.Wrap(err, "Login failed")
+	}
+	return ctx, session, nil
+}
+
+func closeModule(ctx *pkcs11.Ctx, session pkcs11.SessionHandle) {
+	defer ctx.CloseSession(session)
+	defer ctx.Logout(session)
+	defer ctx.Destroy()
+	defer ctx.Finalize()
+}

--- a/keywrap/pkcs11/keywrapper_pkcs11_test.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11_test.go
@@ -1,0 +1,133 @@
+/*
+   Copyright The ocicrypt Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkcs11
+
+import (
+	"github.com/containers/ocicrypt/config"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+var (
+	modulePath string
+	modulePin  string
+)
+
+// init setup the module path and pin in system ENV
+// like: ENC_PKCS11_PATH=/usr/local/lib/softhsm/libsofthsm.so
+//       ENC_PKCS11_PIN=1234
+// if don't have above env variables, skip PKCS11 testing
+func init() {
+	modulePath = os.Getenv("ENC_PKCS11_PATH")
+	modulePin = os.Getenv("ENC_PKCS11_PIN")
+}
+
+func TestKeyWrapPkcs11Invalid(t *testing.T) {
+	if modulePath == "" {
+		t.Skip("Need set env variable [ENC_PKCS11_PATH] for module path.")
+	}
+	if modulePin == "" {
+		t.Skip("Need set env variable [ENC_PKCS11_PIN] for module pin.")
+	}
+
+	cc, err := createInvalidPkcs11Cc()
+
+	kw := NewKeyWrapper()
+
+	data := []byte("This is some secret text")
+
+	wk, err := kw.WrapKeys(cc.EncryptConfig, data)
+	if err != nil {
+		if strings.Contains(err.Error(), "Please check Module path") {
+			return
+		}
+		log.Fatalf("unexpect error: %v", err)
+	}
+
+	ud, err := kw.UnwrapKey(cc.DecryptConfig, wk)
+	if err != nil {
+		return
+	}
+
+	if string(data) != string(ud) {
+		return
+	}
+
+	t.Fatal("Successfully wrap for invalid crypto config")
+}
+
+func TestKeyWrapPkcs11Success(t *testing.T) {
+	if modulePath == "" {
+		t.Skip("Need set env variable [ENC_PKCS11_PATH] for module path.")
+	}
+	if modulePin == "" {
+		t.Skip("Need set env variable [ENC_PKCS11_PIN] for module pin.")
+	}
+
+	cc, err := createValidPkcs11Cc()
+
+	kw := NewKeyWrapper()
+
+	data := []byte("This is some secret text")
+
+	wk, err := kw.WrapKeys(cc.EncryptConfig, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ud, err := kw.UnwrapKey(cc.DecryptConfig, wk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != string(ud) {
+		t.Fatal("Strings don't match")
+	}
+}
+
+func createValidPkcs11Cc() (*config.CryptoConfig, error) {
+	validPkcs11Ccs := &config.CryptoConfig{
+		EncryptConfig: &config.EncryptConfig{
+			Parameters: map[string][][]byte{
+				"modules": {[]byte(modulePath)},
+				"pin":     {[]byte(modulePin)},
+			},
+		},
+		DecryptConfig: &config.DecryptConfig{
+			Parameters: map[string][][]byte{
+				"modules": {[]byte(modulePath)},
+				"pin":     {[]byte(modulePin)},
+			},
+		},
+	}
+	return validPkcs11Ccs, nil
+}
+
+func createInvalidPkcs11Cc() (*config.CryptoConfig, error) {
+	wrongPathPkcs11Ccs := &config.CryptoConfig{
+		EncryptConfig: &config.EncryptConfig{
+			Parameters: map[string][][]byte{
+				// make error module path
+				"modules": {[]byte(modulePath + ".err")},
+				"pin":     {[]byte(modulePin)},
+			},
+		},
+	}
+	return wrongPathPkcs11Ccs, nil
+}

--- a/keywrap/pkcs11/keywrapper_pkcs11_test.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11_test.go
@@ -46,7 +46,7 @@ func TestKeyWrapPkcs11Invalid(t *testing.T) {
 		t.Skip("Need set env variable [ENC_PKCS11_PIN] for module pin.")
 	}
 
-	cc, err := createInvalidPkcs11Cc()
+	cc := createInvalidPkcs11Cc()
 
 	kw := NewKeyWrapper()
 
@@ -80,7 +80,7 @@ func TestKeyWrapPkcs11Success(t *testing.T) {
 		t.Skip("Need set env variable [ENC_PKCS11_PIN] for module pin.")
 	}
 
-	cc, err := createValidPkcs11Cc()
+	cc := createValidPkcs11Cc()
 
 	kw := NewKeyWrapper()
 
@@ -101,7 +101,7 @@ func TestKeyWrapPkcs11Success(t *testing.T) {
 	}
 }
 
-func createValidPkcs11Cc() (*config.CryptoConfig, error) {
+func createValidPkcs11Cc() *config.CryptoConfig {
 	validPkcs11Ccs := &config.CryptoConfig{
 		EncryptConfig: &config.EncryptConfig{
 			Parameters: map[string][][]byte{
@@ -116,10 +116,10 @@ func createValidPkcs11Cc() (*config.CryptoConfig, error) {
 			},
 		},
 	}
-	return validPkcs11Ccs, nil
+	return validPkcs11Ccs
 }
 
-func createInvalidPkcs11Cc() (*config.CryptoConfig, error) {
+func createInvalidPkcs11Cc() *config.CryptoConfig {
 	wrongPathPkcs11Ccs := &config.CryptoConfig{
 		EncryptConfig: &config.EncryptConfig{
 			Parameters: map[string][][]byte{
@@ -129,5 +129,5 @@ func createInvalidPkcs11Cc() (*config.CryptoConfig, error) {
 			},
 		},
 	}
-	return wrongPathPkcs11Ccs, nil
+	return wrongPathPkcs11Ccs
 }

--- a/keywrap/pkcs11/keywrapper_pkcs11_test.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11_test.go
@@ -106,13 +106,13 @@ func createValidPkcs11Cc() (*config.CryptoConfig, error) {
 		EncryptConfig: &config.EncryptConfig{
 			Parameters: map[string][][]byte{
 				"modules": {[]byte(modulePath)},
-				"pin":     {[]byte(modulePin)},
+				"pins":    {[]byte(modulePin)},
 			},
 		},
 		DecryptConfig: &config.DecryptConfig{
 			Parameters: map[string][][]byte{
 				"modules": {[]byte(modulePath)},
-				"pin":     {[]byte(modulePin)},
+				"pins":    {[]byte(modulePin)},
 			},
 		},
 	}
@@ -125,7 +125,7 @@ func createInvalidPkcs11Cc() (*config.CryptoConfig, error) {
 			Parameters: map[string][][]byte{
 				// make error module path
 				"modules": {[]byte(modulePath + ".err")},
-				"pin":     {[]byte(modulePin)},
+				"pins":    {[]byte(modulePin)},
 			},
 		},
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,7 +22,10 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	p11 "github.com/miekg/pkcs11"
+	"golang.org/x/crypto/ssh/terminal"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
@@ -217,4 +220,28 @@ func SortDecryptionKeys(b64ItemList string) (map[string][][]byte, error) {
 	}
 
 	return dcparameters, nil
+}
+
+// IsPkcs11SharedLibrary return true in case the given byte array represents a real pkcs11 dot so file path
+func IsPkcs11SharedLibrary(module string) bool {
+	p := p11.New(module)
+	err := p.Initialize()
+	defer p.Destroy()
+	defer p.Finalize()
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// InputPassword read the password
+func InputPassword(name string) (string, error) {
+	fmt.Printf("Enter %s Password: ", name)
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	fmt.Println()
+	password := string(bytePassword)
+	return strings.TrimSpace(password), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -222,9 +222,12 @@ func SortDecryptionKeys(b64ItemList string) (map[string][][]byte, error) {
 	return dcparameters, nil
 }
 
-// IsPkcs11SharedLibrary return true in case the given byte array represents a real pkcs11 dot so file path
+// IsPkcs11SharedLibrary return true in case the given sting represent a real pkcs11 module file path
 func IsPkcs11SharedLibrary(module string) bool {
-	p := p11.New(module)
+	p := p11.New(strings.TrimSpace(module))
+	if p == nil {
+		return false
+	}
 	err := p.Initialize()
 	defer p.Destroy()
 	defer p.Finalize()


### PR DESCRIPTION
Wrap/Unwrap secret key by PKCS#11 module, but symm encrypt/decrypt keep in go vm.
When module don't have `imgenc` label RSA priv/pub, while create new key pair named `imgenc`.

**manifest** 
add a schema for pkcs11: `org.opencontainers.image.enc.keys.pkcs11`
value of schema is cipher text with Base64
```
{
   "schemaVersion": 2,
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "digest": "sha256:2d4f4b5309b1e41b4f83ae59b44df6d673ef44433c734b14c1c103ebca82c116",
      "size": 3148
   },
   "layers": [
      {
         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip+encrypted",
         "digest": "sha256:6c00e937eb1b456cb2de9a38386a0fc729ed28531d7a8971cfbf9f02a088b6d3",
         "size": 2813316,
         "annotations": {
            "org.opencontainers.image.enc.keys.pkcs11": "GiVNdO+P7QKTgfhIJOfBrLFSDCY7ljFwh9N9UiVbPIDi43BsXpSt+2zhlvOkoqTHXRdmIaG1J4v36vD6p3ZlFYWnk55qqxCGNu89ly1cKup/A2D4KP3PeLhDeJRqNKKY7FzxX5J6C0/tGnojrXlPd2eDnj49FFaR++ctQiAY51w9XEG6KkpaqJgnAp/3YyFHwvIgkCmqmrezdKJUMrC14kvqhxzREJrVTymKyWE43qSdBdq1cCkQh3fNqsyRu0t2TEsF6Rjj+Zi50SP3Fnsg2iiyazs6yUJj6KZt5U6Lr5zrPXGQrpTD6iP4Y4Mczg3QViMQgmql8PJYIQnK9wt4BQ==",
            "org.opencontainers.image.enc.pubopts": "eyJjaXBoZXIiOiJBRVNfMjU2X0NUUl9ITUFDX1NIQTI1NiIsImhtYWMiOiJSeW9VNjExeVlaTGpxSWNTNWxybVNMY0Z2VjR5dVowRkZQQTRBZmp0N0JrPSIsImNpcGhlcm9wdGlvbnMiOnt9fQ=="
         }
      },
      ...
   ]
}
```

Signed-off-by: Gsealy Jiao <jiaojingwei1001@hotmail.com>