### PR TITLE
Implement low level pkcs11 encryption and decryption functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: go
 
 os:
@@ -10,6 +10,12 @@ go:
 matrix:
   include:
     - os: linux
+
+addons:
+  apt:
+    packages:
+    - gnutls-bin
+    - softhsm2
 
 go_import_path: github.com/containers/ocicrypt
 

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ vendor:
 	go mod tidy
 
 test:
-	go test ./...
+	go test ./... -test.v

--- a/crypto/pkcs11/pkcs11helpers.go
+++ b/crypto/pkcs11/pkcs11helpers.go
@@ -1,0 +1,462 @@
+/*
+   Copyright The ocicrypt Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkcs11
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/miekg/pkcs11"
+	"github.com/pkg/errors"
+	pkcs11uri "github.com/stefanberger/go-pkcs11uri"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	// OAEPLabel defines the label we use for OAEP encryption; this cannot be changed
+	OAEPLabel = []byte("")
+	// OAEPDefaultHash defines the default hash used for OAEP encryption; this cannot be changed
+	OAEPDefaultHash = "sha256"
+
+	// OAEPSha1Params describes the OAEP parameters with sha1 hash algorithm; needed by SoftHSM
+	OAEPSha1Params = &pkcs11.OAEPParams{
+		HashAlg:    pkcs11.CKM_SHA_1,
+		MGF:        pkcs11.CKG_MGF1_SHA1,
+		SourceType: pkcs11.CKZ_DATA_SPECIFIED,
+		SourceData: OAEPLabel,
+	}
+	// OAEPSha256Params describes the OAEP parameters with sha256 hash algorithm
+	OAEPSha256Params = &pkcs11.OAEPParams{
+		HashAlg:    pkcs11.CKM_SHA256,
+		MGF:        pkcs11.CKG_MGF1_SHA256,
+		SourceType: pkcs11.CKZ_DATA_SPECIFIED,
+		SourceData: OAEPLabel,
+	}
+	// OEPParams is an array Of OAEP parameters in order we will try to use them
+	OAEPParams = []*pkcs11.OAEPParams{OAEPSha256Params, OAEPSha1Params}
+)
+
+// Pkcs11KeyFile describes the format of the pkcs11 (private) key file
+type Pkcs11KeyFile struct {
+	Pkcs11 struct {
+		Uri string `yaml:"uri"`
+	} `yaml:"pkcs11"`
+}
+
+// Pkcs11KeyFileObject is a representation of the Pkcs11KeyFile with the pkcs11 URI as an object
+type Pkcs11KeyFileObject struct {
+	uri pkcs11uri.Pkcs11URI
+}
+
+// ParsePkcs11KeyFile parses a pkcs11 key file holding a pkcs11 URI describing a private key.
+// The file has the following yaml format:
+// pkcs11:
+//  - uri : <pkcs11 uri>
+// An error is returned if the pkcs11 URI is malformed
+func ParsePkcs11KeyFile(yamlstr []byte) (*Pkcs11KeyFileObject, error) {
+	p11keyfile := Pkcs11KeyFile{}
+
+	err := yaml.Unmarshal([]byte(yamlstr), &p11keyfile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not unmarshal pkcs11 keyfile")
+	}
+
+	p11uri, err := pkcs11uri.New()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not create Pkcs11URI object")
+	}
+	err = p11uri.Parse(p11keyfile.Pkcs11.Uri)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not parse Pkcs11URI from file")
+	}
+
+	return &Pkcs11KeyFileObject{uri: p11uri}, err
+}
+
+// Pkcs11Config describes the layout of a pkcs11 config file
+// The file has the following yaml format:
+// module-directories:
+// - /usr/lib64/pkcs11/
+// allowd-module-paths
+// - /usr/lib64/pkcs11/libsofthsm2.so
+type Pkcs11Config struct {
+	ModuleDirectories  []string `yaml:"module-directories"`
+	AllowedModulePaths []string `yaml:"allowed-module-paths"`
+}
+
+// ParsePkcs11ConfigFile parses a pkcs11 config file hat influences the module search behavior
+// as well as the set of modules that users are allowed to use
+func ParsePkcs11ConfigFile(yamlstr []byte) (Pkcs11Config, error) {
+	p11conf := Pkcs11Config{}
+
+	err := yaml.Unmarshal([]byte(yamlstr), &p11conf)
+	if err != nil {
+		return p11conf, errors.Wrapf(err, "Could not parse Pkcs11Config")
+	}
+	return p11conf, nil
+}
+
+// rsaPublicEncryptOAEP encrypts the given plaintext with the given *rsa.PublicKey; the
+// environment variable OCICRYPT_OAEP_HASHALG can be set to 'sha1' to force usage of sha1 for OAEP (SoftHSM).
+// This function is needed by clients who are using a public key file for pkcs11 encryption
+func rsaPublicEncryptOAEP(pubKey *rsa.PublicKey, plaintext []byte) ([]byte, string, error) {
+	var hashfunc hash.Hash
+	hashalg := OAEPDefaultHash
+
+	// for SoftHSM support we allow the user to choose sha1 as the hash algorithm
+	switch strings.ToLower(os.Getenv("OCICRYPT_OAEP_HASHALG")) {
+	case "sha1":
+		hashfunc = sha1.New()
+		hashalg = "sha1"
+	default:
+		hashfunc = sha256.New()
+	}
+	ciphertext, err := rsa.EncryptOAEP(hashfunc, rand.Reader, pubKey, plaintext, OAEPLabel)
+	if err != nil {
+		return nil, "", errors.Wrapf(err, "rss.EncryptOAEP failed")
+	}
+
+	return ciphertext, hashalg, nil
+}
+
+// pkcs11UriGetLoginParameters gets the parameters necessary for login from the Pkcs11URI
+// PIN and module are mandatory; slot-id is optional and if not found -1 will be returned
+func pkcs11UriGetLoginParameters(p11uri *pkcs11uri.Pkcs11URI) (string, string, int64, error) {
+	pin, err := p11uri.GetPIN()
+	if err != nil {
+		return "", "", 0, errors.Wrap(err, "No PIN available in pkcs11 URI")
+	}
+
+	module, err := p11uri.GetModule()
+	if err != nil {
+		return "", "", 0, errors.Wrap(err, "No module available in pkcs11 URI")
+	}
+
+	slotid := int64(-1)
+
+	slot, ok := p11uri.GetPathAttribute("slot-id", false)
+	if ok {
+		slotid, err = strconv.ParseInt(slot, 10, 64)
+		if err != nil {
+			return "", "", 0, errors.Wrap(err, "slot-id is not a valid number")
+		}
+		if slotid < 0 {
+			return "", "", 0, fmt.Errorf("slot-id is a negative number")
+		}
+		if uint64(slotid) > 0xffffffff {
+			return "", "", 0, fmt.Errorf("slot-id is larger than 32 bit")
+		}
+	}
+
+	return pin, module, slotid, nil
+}
+
+// pkcs11UriGetKeyLabel gets the key label by retrieving the value of the 'object' attribute
+func pkcs11UriGetKeyLabel(p11uri *pkcs11uri.Pkcs11URI) (string, error) {
+	serial, ok := p11uri.GetPathAttribute("object", false)
+	if !ok {
+		return "", errors.New("No 'object' attribute found in pkcs11 URI")
+	}
+	return serial, nil
+}
+
+// pkcs11UriLogin uses the given pkcs11 URI to select the pkcs11 module (share libary) and to get
+// the PIN to use for login; if the URI contains a slot-id, the given slot-id will be used, otherwise
+// one slot after the other will be attempted and the first one where login succeeds will be used
+func pkcs11UriLogin(p11uri *pkcs11uri.Pkcs11URI) (ctx *pkcs11.Ctx, session pkcs11.SessionHandle, err error) {
+	pin, module, slotid, err := pkcs11UriGetLoginParameters(p11uri)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	p11ctx := pkcs11.New(module)
+	if p11ctx == nil {
+		return nil, 0, errors.New("Please check module path, input is: " + module)
+	}
+
+	err = p11ctx.Initialize()
+	if err != nil {
+		p11Err := err.(pkcs11.Error)
+		if p11Err != pkcs11.CKR_CRYPTOKI_ALREADY_INITIALIZED {
+			return nil, 0, errors.Wrap(err, "Initialize failed")
+		}
+	}
+
+	if slotid >= 0 {
+		session, err = p11ctx.OpenSession(uint(slotid), pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+		if err != nil {
+			return nil, 0, errors.Wrapf(err, "OpenSession to slot %d failed", slotid)
+		}
+		err = p11ctx.Login(session, pkcs11.CKU_USER, pin)
+		if err != nil {
+			_ = p11ctx.CloseSession(session)
+			return nil, 0, errors.Wrap(err, "Could not login to device")
+		}
+	} else {
+		slots, err := p11ctx.GetSlotList(true)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "GetSlotList failed")
+		}
+
+		loggedin := false
+		for _, slot := range slots {
+			session, err = p11ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+			if err != nil {
+				continue
+			}
+			err = p11ctx.Login(session, pkcs11.CKU_USER, pin)
+			if err == nil {
+				loggedin = true
+				break
+			}
+			_ = p11ctx.CloseSession(session)
+		}
+		if !loggedin {
+			return nil, 0, errors.New("Could not log in to any slots")
+		}
+	}
+
+	return p11ctx, session, nil
+}
+
+func pkcs11Logout(ctx *pkcs11.Ctx, session pkcs11.SessionHandle) {
+	_ = ctx.Logout(session)
+	_ = ctx.CloseSession(session)
+	_ = ctx.Finalize()
+	ctx.Destroy()
+}
+
+// findObject finds an object of the given class with the given label
+func findObject(p11ctx *pkcs11.Ctx, session pkcs11.SessionHandle, class uint, label string) (pkcs11.ObjectHandle, error) {
+	template := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, label),
+	}
+
+	if err := p11ctx.FindObjectsInit(session, template); err != nil {
+		return 0, errors.Wrap(err, "FindObjectsInit failed")
+	}
+
+	obj, _, err := p11ctx.FindObjects(session, 1)
+	if err != nil {
+		return 0, errors.Wrap(err, "FindObjects failed")
+	}
+
+	if err := p11ctx.FindObjectsFinal(session); err != nil {
+		return 0, errors.Wrap(err, "FindObjectsFinal failed")
+	}
+	if len(obj) > 0 {
+		return obj[0], nil
+	}
+
+	return 0, errors.Errorf("Could not find any object with the label '%s'", label)
+}
+
+// publicEncryptOAEP uses a public key described by a pkcs11 URI to OAEP encrypt the given plaintext
+func publicEncryptOAEP(pubKey *pkcs11uri.Pkcs11URI, plaintext []byte) ([]byte, string, error) {
+	p11ctx, session, err := pkcs11UriLogin(pubKey)
+	if err != nil {
+		return nil, "", err
+	}
+	defer pkcs11Logout(p11ctx, session)
+
+	label, err := pkcs11UriGetKeyLabel(pubKey)
+	if err != nil {
+		return nil, "", err
+	}
+
+	p11PubKey, err := findObject(p11ctx, session, pkcs11.CKO_PUBLIC_KEY, label)
+	if err != nil {
+		return nil, "", err
+	}
+
+	hashalg := OAEPDefaultHash
+
+	// SoftHSM only accepts sha1 for OAEP; nevertheless we try sha256 first, and fall back to sha1 otherwise
+	for _, oaep := range OAEPParams {
+		err = p11ctx.EncryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_OAEP, oaep)}, p11PubKey)
+		if err == nil {
+			if oaep.HashAlg == pkcs11.CKM_SHA_1 {
+				hashalg = "sha1"
+			}
+			break
+		}
+	}
+	if err != nil {
+		return nil, "", errors.Wrap(err, "EncryptInit error")
+	}
+
+	ciphertext, err := p11ctx.Encrypt(session, plaintext)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "Encrypt failed")
+	}
+	return ciphertext, hashalg, nil
+}
+
+// privateDecryptOAEP uses a pkcs11 URI describing a private key to OAEP decrypt a ciphertext
+func privateDecryptOAEP(privKey *pkcs11uri.Pkcs11URI, ciphertext []byte, hashalg string) ([]byte, error) {
+	p11ctx, session, err := pkcs11UriLogin(privKey)
+	if err != nil {
+		return nil, err
+	}
+	defer pkcs11Logout(p11ctx, session)
+
+	label, err := pkcs11UriGetKeyLabel(privKey)
+	if err != nil {
+		return nil, err
+	}
+
+	p11PrivKey, err := findObject(p11ctx, session, pkcs11.CKO_PRIVATE_KEY, label)
+	if err != nil {
+		return nil, err
+	}
+
+	oaep := OAEPSha256Params
+	switch hashalg {
+	case "sha1":
+		oaep = OAEPSha1Params
+	}
+
+	err = p11ctx.DecryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_RSA_PKCS_OAEP, oaep)}, p11PrivKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "DecryptInit failed")
+	}
+	plaintext, err := p11ctx.Decrypt(session, ciphertext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Decrypt failed")
+	}
+	return plaintext, err
+}
+
+//
+// The following part deals with the JSON formatted message for multiple pkcs11 recipients
+//
+
+// Pkcs11Blob holds the encrypted blobs for all recipients; this is what we will put into the image's annotations
+type Pkcs11Blob struct {
+	Recipients []Pkcs11Recipient `json:"recipients"`
+}
+
+// Pkcs11Recipient holds the b64-encoded and encrypted blob for a particular recipient
+type Pkcs11Recipient struct {
+	Blob string `json:"blob"`
+	Hash string `json:"hash,omitempty"`
+}
+
+// EncryptMultiple encrypts for one or multiple pkcs11 devices; the public keys passed to this function
+// may either be *rsa.PublicKey or *pkcs11uri.Pkcs11URI; the returned byte array is a JSON string of the
+// following format:
+// {
+//   recipients: [  // recipient list
+//     {
+//        "blob": <base64 encoded RSA OAEP encrypted blob>
+//        "hash": <hash used for OAEP other than 'sha256'>
+//     } ,
+//     {
+//        "blob": <base64 encoded RSA OAEP encrypted blob>
+//        "hash": <hash used for OAEP other than 'sha256'>
+//     } ,
+//     [...]
+//   ]
+// }
+func EncryptMultiple(pubKeys []interface{}, data []byte) ([]byte, error) {
+	var (
+		ciphertext []byte
+		err        error
+		pkcs11blob Pkcs11Blob = Pkcs11Blob{}
+		hashalg    string
+	)
+
+	for _, pubKey := range pubKeys {
+		switch pkey := pubKey.(type) {
+		case *rsa.PublicKey:
+			ciphertext, hashalg, err = rsaPublicEncryptOAEP(pkey, data)
+		case *pkcs11uri.Pkcs11URI:
+			ciphertext, hashalg, err = publicEncryptOAEP(pkey, data)
+		default:
+			err = errors.Errorf("Unsupported key object type for pkcs11 public key")
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if hashalg == OAEPDefaultHash {
+			hashalg = ""
+		}
+		recipient := Pkcs11Recipient{
+			Blob: base64.StdEncoding.EncodeToString(ciphertext),
+			Hash: hashalg,
+		}
+
+		pkcs11blob.Recipients = append(pkcs11blob.Recipients, recipient)
+	}
+	return json.Marshal(&pkcs11blob)
+}
+
+// Decrypt tries to decrypt one of the recipients' blobs using a pkcs11 private key.
+// The input pkcs11blobstr is a string with the following format:
+// {
+//   recipients: [  // recipient list
+//     {
+//        "blob": <base64 encoded RSA OAEP encrypted blob>
+//        "hash": <hash used for OAEP other than 'sha256'>
+//     } ,
+//     {
+//        "blob": <base64 encoded RSA OAEP encrypted blob>
+//        "hash": <hash used for OAEP other than 'sha256'>
+//     } ,
+//     [...]
+// }
+func Decrypt(privKeys []*pkcs11uri.Pkcs11URI, pkcs11blobstr []byte) ([]byte, error) {
+	pkcs11blob := Pkcs11Blob{}
+	err := json.Unmarshal(pkcs11blobstr, &pkcs11blob)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not parse Pkcs11Blob")
+	}
+
+	// since we do trial and error, collect all encountered errors
+	errs := ""
+
+	for _, recipient := range pkcs11blob.Recipients {
+		ciphertext, err := base64.StdEncoding.DecodeString(recipient.Blob)
+		if err != nil || len(ciphertext) == 0 {
+			// This should never happen... we skip over decoding issues
+			errs += fmt.Sprintf("Base64 decoding failed: %s\n", err)
+			continue
+		}
+		// try all keys until one works
+		for _, privKey := range privKeys {
+			plaintext, err := privateDecryptOAEP(privKey, ciphertext, recipient.Hash)
+			if err == nil {
+				return plaintext, nil
+			}
+			uri, _ := privKey.Format()
+			errs += fmt.Sprintf("%s : %s\n", uri, err)
+		}
+	}
+
+	return nil, errors.Errorf("Could not find a pkcs11 key for decryption:\n%s", errs)
+}

--- a/crypto/pkcs11/pkcs11helpers_test.go
+++ b/crypto/pkcs11/pkcs11helpers_test.go
@@ -1,0 +1,209 @@
+/*
+   Copyright The ocicrypt Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkcs11
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	pkcs11uri "github.com/stefanberger/go-pkcs11uri"
+)
+
+var (
+	SOFTHSM_SETUP = "../../scripts/softhsm_setup"
+)
+
+func getPkcs11Config(t *testing.T) Pkcs11Config {
+	// we need to provide a configuration file so that on the various distros
+	// the libsofthsm2.so will be found by searching directories
+	config := `module-directories:
+ - /usr/lib64/pkcs11/  # Fedora
+ - /usr/lib/softhsm/   # Ubuntu
+`
+	p11conf, err := ParsePkcs11ConfigFile([]byte(config))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p11conf
+}
+
+func TestParsePkcs11KeyFileGood(t *testing.T) {
+	data := `pkcs11:
+   uri: pkcs11:slot-id=2053753261?module-name=softhsm2&pin-value=1234
+`
+	p11keyfileobj, err := ParsePkcs11KeyFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p11conf := getPkcs11Config(t)
+	p11keyfileobj.uri.SetModuleDirectories(p11conf.ModuleDirectories)
+
+	module, err := p11keyfileobj.uri.GetModule()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasSuffix(module, "/libsofthsm2.so") {
+		t.Fatalf("Unexpect module '%s'", module)
+	}
+}
+
+func TestParsePkcs11KeyFileBad(t *testing.T) {
+	data := `pkcs11:
+   uri: foobar
+`
+	_, err := ParsePkcs11KeyFile([]byte(data))
+	if err == nil {
+		t.Fatalf("Parsing the malformed pkcs11 key file should have failed")
+	}
+}
+
+func runSoftHSMSetup(t *testing.T) string {
+	cmd := exec.Command(SOFTHSM_SETUP, "setup")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println(out.String())
+		t.Fatal(err)
+	}
+
+	o := out.String()
+	idx := strings.Index(o, "pkcs11:")
+	if idx < 0 {
+		t.Fatalf("Could not find pkcs11 URI in output")
+	}
+
+	return strings.TrimRight(o[idx:], "\n ")
+}
+
+func runSoftHSMGetPubkey(t *testing.T) string {
+	cmd := exec.Command(SOFTHSM_SETUP, "getpubkey")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println(out.String())
+		t.Fatal(err)
+	}
+
+	return out.String()
+}
+
+func runSoftHSMTeardown(t *testing.T) {
+	cmd := exec.Command(SOFTHSM_SETUP, "teardown")
+	_ = cmd.Run()
+}
+
+func TestPkcs11EncryptDecrypt(t *testing.T) {
+	// We always need the query attributes  'pin-value' and 'module-name'
+	// for SoftHSM2 the only other important attribute is 'object' (= the 'label')
+	p11pubkeyuristr := runSoftHSMSetup(t)
+	defer runSoftHSMTeardown(t)
+
+	p11pubkeyuri, err := pkcs11uri.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = p11pubkeyuri.Parse(p11pubkeyuristr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testinput := "Hello World!"
+
+	p11conf := getPkcs11Config(t)
+	p11pubkeyuri.SetModuleDirectories(p11conf.ModuleDirectories)
+
+	pubKeys := make([]interface{}, 1)
+	pubKeys[0] = &p11pubkeyuri
+	p11json, err := EncryptMultiple(pubKeys, []byte(testinput))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// for SoftHSM we can just reuse the public key URI
+	privKeys := make([]*pkcs11uri.Pkcs11URI, 1)
+	privKeys[0] = &p11pubkeyuri
+	plaintext, err := Decrypt(privKeys, p11json)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(plaintext) != testinput {
+		t.Fatalf("plaintext '%s' is not expected '%s'", plaintext, testinput)
+	}
+}
+
+func TestPkcs11EncryptDecryptPubkey(t *testing.T) {
+	// We always need the query attributes  'pin-value' and 'module-name'
+	// for SoftHSM2 the only other important attribute is 'object' (= the 'label')
+	p11pubkeyuristr := runSoftHSMSetup(t)
+	defer runSoftHSMTeardown(t)
+
+	pubkeypem := runSoftHSMGetPubkey(t)
+
+	block, _ := pem.Decode([]byte(pubkeypem))
+	if block == nil {
+		t.Fatal("failed to parse PEM block containing the public key")
+	}
+	rsapubkey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testinput := "Hello World!"
+
+	os.Setenv("OCICRYPT_OAEP_HASHALG", "sha1")
+
+	pubKeys := make([]interface{}, 1)
+	pubKeys[0] = rsapubkey
+	p11json, err := EncryptMultiple(pubKeys, []byte(testinput))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p11pubkeyuri, err := pkcs11uri.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = p11pubkeyuri.Parse(p11pubkeyuristr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p11conf := getPkcs11Config(t)
+	p11pubkeyuri.SetModuleDirectories(p11conf.ModuleDirectories)
+
+	// for SoftHSM we can just reuse the public key URI
+	privKeys := make([]*pkcs11uri.Pkcs11URI, 1)
+	privKeys[0] = &p11pubkeyuri
+	plaintext, err := Decrypt(privKeys, p11json)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(plaintext) != testinput {
+		t.Fatalf("plaintext '%s' is not expected '%s'", plaintext, testinput)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,15 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/miekg/pkcs11 v1.0.3
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.8.1
+	github.com/stefanberger/go-pkcs11uri v0.0.0-20200729195014-78529f99efb9
 	github.com/stretchr/testify v1.3.0 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/miekg/pkcs11 v1.0.3 h1:iMwmD7I5225wv84WxIG/bmxz9AXjWvTWIbM/TYHvWtw=
+github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
@@ -10,6 +12,8 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20200729195014-78529f99efb9 h1:obdZ/NWlVgfAiH+4wRux+idJQxn9fcoBO/CbT9oH4Xw=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20200729195014-78529f99efb9/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -27,5 +31,9 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/p
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/scripts/softhsm_setup
+++ b/scripts/softhsm_setup
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+# This script may not work with softhsm2 2.0.0 but with >= 2.2.0
+
+if [ -z "$(type -P p11tool)" ]; then
+	echo "Need p11tool from gnutls"
+	exit 77
+fi
+
+if [ -z "$(type -P softhsm2-util)" ]; then
+	echo "Need softhsm2-util from softhsm2 package"
+	exit 77
+fi
+
+NAME=ocicrypt-test
+PIN=${PIN:-1234}
+SO_PIN=${SO_PIN:-1234}
+
+UNAME_S="$(uname -s)"
+
+case "${UNAME_S}" in
+Darwin)
+	msg=$(sudo -v -n)
+	if [ $? -ne 0 ]; then
+		echo "Need password-less sudo rights on OS X to change /etc/gnutls/pkcs11.conf"
+		exit 1
+	fi
+	;;
+esac
+
+teardown_softhsm() {
+	local configdir=~/.config/softhsm2
+	local configfile=${configdir}/softhsm2.conf
+	local bakconfigfile=${configfile}.bak
+	local tokendir=${configdir}/tokens
+
+	softhsm2-util --token "${NAME}" --delete-token &>/dev/null
+
+	case "${UNAME_S}" in
+	Darwin*)
+		if [ -f /etc/gnutls/pkcs11.conf.bak ]; then
+			sudo rm -f /etc/gnutls/pkcs11.conf
+			sudo mv /etc/gnutls/pkcs11.conf.bak \
+			   /etc/gnutls/pkcs11.conf &>/dev/null
+		fi
+		;;
+	esac
+
+	if [ -f "$bakconfigfile" ]; then
+		mv "$bakconfigfile" "$configfile"
+	else
+		rm -f "$configfile"
+	fi
+	if [ -d "$tokendir" ]; then
+		rm -rf "${tokendir}"
+	fi
+	return 0
+}
+
+setup_softhsm() {
+	local msg tokenuri keyuri
+	local configdir=~/.config/softhsm2
+	local configfile=${configdir}/softhsm2.conf
+	local bakconfigfile=${configfile}.bak
+	local tokendir=${configdir}/tokens
+	local rc
+
+	case "${UNAME_S}" in
+	Darwin*)
+		if [ -f /etc/gnutls/pkcs11.conf.bak ]; then
+			echo "/etc/gnutls/pkcs11.conf.bak already exists; need to 'teardown' first"
+			return 1
+		fi
+		sudo mv /etc/gnutls/pkcs11.conf \
+			/etc/gnutls/pkcs11.conf.bak &>/dev/null
+		if [ $(id -u) -eq 0 ]; then
+			SONAME="$(sudo -u nobody brew ls --verbose softhsm | \
+				  grep -E "\.so$")"
+		else
+			SONAME="$(brew ls --verbose softhsm | \
+				  grep -E "\.so$")"
+		fi
+		sudo mkdir -p /etc/gnutls &>/dev/null
+		sudo bash -c "echo "load=${SONAME}" > /etc/gnutls/pkcs11.conf"
+		;;
+	esac
+
+	if ! [ -d $configdir ]; then
+		mkdir -p $configdir
+	fi
+	mkdir -p ${tokendir}
+
+	if [ -f $configfile ]; then
+		mv "$configfile" "$bakconfigfile"
+	fi
+
+	if ! [ -f $configfile ]; then
+		cat <<_EOF_ > $configfile
+directories.tokendir = ${tokendir}
+objectstore.backend = file
+log.level = DEBUG
+slots.removable = false
+_EOF_
+	fi
+
+	msg=$(p11tool --list-tokens 2>&1 | grep "token=${NAME}" | tail -n1)
+	if [ $? -ne 0 ]; then
+		echo "Could not list existing tokens"
+		echo "$msg"
+	fi
+	tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+
+	if [ -z "$tokenuri" ]; then
+		msg=$(softhsm2-util \
+			--init-token --pin ${PIN} --so-pin ${SO_PIN} \
+			--free --label ${NAME} 2>&1)
+		if [ $? -ne 0 ]; then
+			echo "Could not initialize token"
+			echo "$msg"
+			return 2
+		fi
+
+		slot=$(echo "$msg" | \
+		       sed -n 's/.* reassigned to slot \([0-9]*\)$/\1/p')
+		if [ -z "$slot" ]; then
+			slot=$(softhsm2-util --show-slots | \
+			       grep -E "^Slot " | head -n1 |
+			       sed -n 's/Slot \([0-9]*\)/\1/p')
+			if [ -z "$slot" ]; then
+				echo "Could not parse slot number from output."
+				echo "$msg"
+				return 3
+			fi
+		fi
+
+		msg=$(p11tool --list-tokens 2>&1 | \
+			grep "token=${NAME}" | tail -n1)
+		if [ $? -ne 0 ]; then
+			echo "Could not list existing tokens"
+			echo "$msg"
+		fi
+		tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+		if [ -z "${tokenuri}" ]; then
+			echo "Could not get tokenuri!"
+			return 4
+		fi
+
+		# more recent versions of p11tool have --generate-privkey ...
+		msg=$(GNUTLS_PIN=1234 p11tool \
+			--generate-privkey=rsa --label mykey --login \
+			"${tokenuri}" 2>&1)
+		if [ $? -ne 0 ]; then
+			# ... older versions have --generate-rsa
+			msg=$(GNUTLS_PIN=1234 p11tool \
+				--generate-rsa --label mykey --login \
+				"${tokenuri}" 2>&1)
+			if [ $? -ne 0 ]; then
+				echo "Could not create RSA key!"
+				echo "$msg"
+				return 5
+			fi
+		fi
+	fi
+
+	getkeyuri_softhsm $slot
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		teardown_softhsm
+	fi
+
+	return $rc
+}
+
+_getkeyuri_softhsm() {
+	local msg tokenuri keyuri
+
+	msg=$(p11tool --list-tokens 2>&1 | grep "token=${NAME}")
+	if [ $? -ne 0 ]; then
+		echo "Could not list existing tokens"
+		echo "$msg"
+		return 5
+	fi
+	tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+	if [ -z "$tokenuri" ]; then
+		echo "Could not get token URL"
+		echo "$msg"
+		return 6
+	fi
+	msg=$(p11tool --list-all ${tokenuri} 2>&1)
+	if [ $? -ne 0 ]; then
+		echo "Could not list object under token $tokenuri"
+		echo "$msg"
+		softhsm2-util --show-slots
+		return 7
+	fi
+
+	keyuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+	if [ -z "$keyuri" ]; then
+		echo "Could not get key URL"
+		echo "$msg"
+		return 8
+	fi
+	echo "$keyuri"
+	return 0
+}
+
+getkeyuri_softhsm() {
+	local keyuri rc
+
+	keyuri=$(_getkeyuri_softhsm)
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		return $rc
+	fi
+	echo "keyuri: $keyuri?pin-value=${PIN}&module-name=softhsm2"
+	return 0
+}
+
+getpubkey_softhsm() {
+	local keyuri rc
+
+	keyuri=$(_getkeyuri_softhsm)
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		return $rc
+	fi
+	GNUTLS_PIN=${PIN} p11tool --export-pubkey "${keyuri}" --login 2>/dev/null
+	return $?
+}
+
+usage() {
+	cat <<_EOF_
+Usage: $0 [command]
+
+Supported commands are:
+
+setup      : Setup the user's account for softhsm and create a
+             token and key with a test configuration
+
+getkeyuri  : Get the key's URL; may only be called after setup
+
+getpubkey  : Get the public key in PEM format; may only be called after setup
+
+teardown   : Remove the temporary softhsm test configuration
+
+_EOF_
+}
+
+main() {
+	local ret
+
+	if [ $# -lt 1 ]; then
+		usage $0
+		echo -e "Missing command.\n\n"
+		return 1
+	fi
+	case "$1" in
+	setup)
+		setup_softhsm
+		ret=$?
+		;;
+	getkeyuri)
+		getkeyuri_softhsm
+		ret=$?
+		;;
+	getpubkey)
+		getpubkey_softhsm
+		ret=$?
+		;;
+	teardown)
+		teardown_softhsm
+		ret=$?
+		;;
+	*)
+		echo -e "Unsupported command: $1\n\n"
+		usage $0
+		ret=1
+	esac
+	return $ret
+}
+
+main "$@"
+exit $?


### PR DESCRIPTION
With code recycled from Gsealy Jiao <jiaojingwei1001@hotmail.com>

This PR today does the following:

-   Extends the existing function for parsing public keys with parsing a pkcs11 URI as a public key and returns a pkcs11uri object for it
-   Extends the existing function for parsing a private key file content that describes the private key in form of yaml; the actual key is also described as a pkcs11 URI; the function then returns a pkcs11uri object for the private key
-   Implements a function to parse a pkcs11 config file that is needed for declaring the paths where pkcs11 modules are to be found on a distro; it also allows to restrict the modules that can be used; the entries found in the config file are used as parameters to a pkcs11uri object; the assumption is that pkcs11 URIs can use module-name=softhsm2 to describe /path/to/libsofthsm2.so since this would allow for system-independent support for picking a client shared library (as described in RFC 7512)
-   Adds a low level Encrypt function that supports OAEP encryption using pkcs11 URI objects and *rsa.PublicKey objects (multiple recipients); it generates a JSON object with the encrypted blob base 64 encoded and embedded in a per-recipient entry
-   Adds a low level Decrypt function that supports decryption using pkcs11 URI objects describing private keys; all keys will be tried with all entries found in the given JSON and once a decryption succeeds, the plaintext is returned
-   Adds test cases for setting up a SoftHSM2 (starting with Ubuntu Bionic, SoftHSM 2.2) covering the Encrypt and Decrypt function as well as parsing of private key files (yaml format) and pkcs11 config files influencing the module search behavior of the pkcs11uri library objects


I am upgrading the Travis environment to Xenial due to softhsm2
and p11tool.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>