### PR TITLE
Rework public key

### DIFF
--- a/crypto/pkcs11/pkcs11helpers.go
+++ b/crypto/pkcs11/pkcs11helpers.go
@@ -59,11 +59,16 @@ var (
 	OAEPParams = []*pkcs11.OAEPParams{OAEPSha256Params, OAEPSha1Params}
 )
 
-// Pkcs11KeyFile describes the format of the pkcs11 (private) key file
+// Pkcs11KeyFile describes the format of the pkcs11 (private) key file.
+// It also carries pkcs11 module related environment variables that are transferred to the
+// Pkcs11URI object and activated when the pkcs11 module is used.
 type Pkcs11KeyFile struct {
 	Pkcs11 struct {
 		Uri string `yaml:"uri"`
 	} `yaml:"pkcs11"`
+	Module struct {
+		Env map[string]string `yaml:"env,omitempty"`
+	} `yaml:"module"`
 }
 
 // Pkcs11KeyFileObject is a representation of the Pkcs11KeyFile with the pkcs11 URI as an object
@@ -104,6 +109,7 @@ func ParsePkcs11KeyFile(yamlstr []byte) (*Pkcs11KeyFileObject, error) {
 	if err != nil {
 		return nil, err
 	}
+	p11uri.SetEnvMap(p11keyfile.Module.Env)
 
 	return &Pkcs11KeyFileObject{Uri: p11uri}, err
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.9.1
-	github.com/stefanberger/go-pkcs11uri v0.0.0-20200818151115-15fd140e77b8
+	github.com/stefanberger/go-pkcs11uri v0.0.0-20200901134020-a3ec7c3624da
 	github.com/stretchr/testify v1.3.0 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20200729195014-78529f99efb9 h1:obdZ/
 github.com/stefanberger/go-pkcs11uri v0.0.0-20200729195014-78529f99efb9/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20200818151115-15fd140e77b8 h1:xx8nqSsQV45UpCNm+2GcyQDZgG3cVuv24sXNgg35T5E=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20200818151115-15fd140e77b8/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20200901134020-a3ec7c3624da h1:nG+J2N1b1YswENeVYY+cHaj/PHvn8EFPMjMmk5vmZTc=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20200901134020-a3ec7c3624da/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containers/ocicrypt/crypto/pkcs11"
 
 	"github.com/pkg/errors"
-	pkcs11uri "github.com/stefanberger/go-pkcs11uri"
 	"golang.org/x/crypto/openpgp"
 	json "gopkg.in/square/go-jose.v2"
 )
@@ -64,16 +63,10 @@ func parsePkcs11PrivateKeyYaml(yaml []byte, prefix string) (*pkcs11.Pkcs11KeyFil
 	return pkcs11.ParsePkcs11KeyFile(yaml)
 }
 
-// parsePkcs11URIPublicKey parses the input byte array as a pkcs11 URI describing a public key
-func parsePkcs11URIPublicKey(pkcs11uristr []byte, prefix string) (*pkcs11uri.Pkcs11URI, error) {
-	p11uri := pkcs11uri.New()
-
-	err := p11uri.Parse(string(pkcs11uristr))
-	if err != nil {
-		return nil, errors.Wrapf(err, "%s: Could not parse Pkcs11URI '%s'", prefix, pkcs11uristr)
-	}
-	// if the URI does not have enough attributes, we will throw an error when encrypting
-	return p11uri, nil
+// parsePkcs11URIPublicKey parses the input byte array as a pkcs11 key file yaml
+func parsePkcs11PublicKeyYaml(yaml []byte, prefix string) (*pkcs11.Pkcs11KeyFileObject, error) {
+	// if the URI does not have enough attributes, we will throw an error when decrypting
+	return pkcs11.ParsePkcs11KeyFile(yaml)
 }
 
 // IsPasswordError checks whether an error is related to a missing or wrong
@@ -157,7 +150,7 @@ func ParsePublicKey(pubKey []byte, prefix string) (interface{}, error) {
 		} else {
 			key, err = parseJWKPublicKey(pubKey, prefix)
 			if err != nil {
-				key, err = parsePkcs11URIPublicKey(pubKey, prefix)
+				key, err = parsePkcs11PublicKeyYaml(pubKey, prefix)
 			}
 		}
 	}


### PR DESCRIPTION
This PR reworks the usage of the public keys. 

- We extend the YAML file with support for pkcs11 module specific environment variables that we already set before the usage of the pkcs11 module. We now require these types of YAML files also to be used for public keys since  the YAML is more expressive than the plain URI.
- Relax the requirements for a PIN. At least for softhsm2 public key access only a session is needed but no login is required.