### PR TITLE
Split key filename in processx509Certs to account for password

### DIFF
--- a/helpers/parse_helpers.go
+++ b/helpers/parse_helpers.go
@@ -88,7 +88,7 @@ func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, []
 func processx509Certs(keys []string) ([][]byte, error) {
 	var x509s [][]byte
 	for _, key := range keys {
-		tmp, err := ioutil.ReadFile(key)
+		tmp, err := ioutil.ReadFile(strings.Split(key, ":")[0])
 		if err != nil {
 			return nil, errors.Wrap(err, "Unable to read file")
 		}

--- a/helpers/parse_helpers.go
+++ b/helpers/parse_helpers.go
@@ -230,7 +230,7 @@ func CreateDecryptCryptoConfigWithOpts(keys []string, decRecipients []string, op
 	_, err = createGPGClient(context)
 	gpgInstalled := err == nil
 	if gpgInstalled {
-		if len(gpgSecretKeyRingFiles) == 0 && len(privKeys) == 0 && descs != nil {
+		if len(gpgSecretKeyRingFiles) == 0 && len(privKeys) == 0 && len(pkcs11Yamls) == 0 && descs != nil {
 			// Get pgp private keys from keyring only if no private key was passed
 			gpgPrivKeys, gpgPrivKeyPasswords, err := getGPGPrivateKeys(context, gpgSecretKeyRingFiles, descs, true)
 			if err != nil {


### PR DESCRIPTION
Split the key filename in processx509Certs to account for a possible
password after an optional ':'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>