### PR TITLE
pkcs11: Bring pkcs11 module of out experimental stage

### DIFF
--- a/config/pkcs11config/config.go
+++ b/config/pkcs11config/config.go
@@ -105,6 +105,7 @@ func getDefaultCryptoConfigOpts() (*OcicryptConfig, error) {
 // GetUserPkcs11Config gets the user's Pkcs11Conig either from a configuration file or if none is
 // found the default ones are returned
 func GetUserPkcs11Config() (*pkcs11.Pkcs11Config, error) {
+	fmt.Print("Note: pkcs11 support is currently experimental\n")
 	ic, err := getConfiguration()
 	if err != nil {
 		return &pkcs11.Pkcs11Config{}, err

--- a/docs/keyprovider.md
+++ b/docs/keyprovider.md
@@ -34,7 +34,7 @@ The config file consists for list of protocols that can be used for either encry
         "key-providers": {
             "simplecrypt": {
                 "cmd": {
-                    "name":"/home/vagrant/simplecrypt",
+                    "path":"/home/vagrant/simplecrypt",
                     "args": []
                 }
             }

--- a/docs/pkcs11.md
+++ b/docs/pkcs11.md
@@ -205,25 +205,30 @@ With containerd imgcrypt, the tool to encrypt/decrypt images is `ctr-enc`.
 
 ### Encryping with Public Key
 
+```
 $ OCICRYPT_CONFIG=internal ./bin/ctr-enc images encrypt --recipient pkcs11:myPkcs11Key.yaml docker.io/library/alpine:latest alpine.enc.pkcs11key:latest
 Encrypting docker.io/library/alpine:latest to alpine.enc.pkcs11key:latest
-WARNING: Pkcs11 support is currently experimental and images encrypted with it will not be decryptable once it is production ready.
+Note: Pkcs11 support is currently experimental
+```
 
 ### Encryping with PKCS11 Key Configuration
 
+```
 $ OCICRYPT_CONFIG=internal ./bin/ctr-enc images encrypt --recipient pkcs11:pubkey.pem docker.io/library/alpine:latest alpine.enc.pkcs11pubkey:latest
 Encrypting docker.io/library/alpine:latest to alpine.enc.pkcs11pubkey:latest
-WARNING: Pkcs11 support is currently experimental and images encrypted with it will not be decryptable once it is production ready.
+Note: Pkcs11 support is currently experimental
+```
 
 
 ### Decrypting with both images encrypted above with PKCS11 Key Configuration 
 
+```
 $ OCICRYPT_CONFIG=internal ./bin/ctr-enc images decrypt --key myPkcs11Key.yaml alpine.enc.pkcs11key:latest alpine.dec.pkcs11key:latest
 Decrypting alpine.enc.pkcs11key:latest to alpine.dec.pkcs11key:latest
 
 $ OCICRYPT_CONFIG=internal ./bin/ctr-enc images decrypt --key myPkcs11Key.yaml alpine.enc.pkcs11pubkey:latest alpine.dec.pkcs11pubkey:latest
 Decrypting alpine.enc.pkcs11pubkey:latest to alpine.dec.pkcs11pubkey:latest
-
+```
 
 ## skopeo
 

--- a/go.sum
+++ b/go.sum
@@ -42,9 +42,12 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
@@ -70,6 +73,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200817155316-9781c653f443 h1:X18bCaipMcoJGm27Nv7zr4XYPKGUy92GtqboKC2Hxaw=
 golang.org/x/sys v0.0.0-20200817155316-9781c653f443/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/helpers/parse_helpers.go
+++ b/helpers/parse_helpers.go
@@ -337,7 +337,7 @@ func CreateCryptoConfig(recipients []string, keys []string) (encconfig.CryptoCon
 			encryptCcs = append(encryptCcs, jweCc)
 		}
 		var p11conf *pkcs11.Pkcs11Config
-		if len(pkcs11Yamls) > 0 {
+		if len(pkcs11Yamls) > 0 || len(pkcs11Pubkeys) > 0 {
 			p11conf, err = pkcs11config.GetUserPkcs11Config()
 			if err != nil {
 				return encconfig.CryptoConfig{}, err

--- a/keywrap/pkcs11/keywrapper_pkcs11.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11.go
@@ -29,7 +29,7 @@ type pkcs11KeyWrapper struct {
 }
 
 func (kw *pkcs11KeyWrapper) GetAnnotationID() string {
-	return "org.opencontainers.image.enc.keys.experimental.pkcs11"
+	return "org.opencontainers.image.enc.keys.pkcs11"
 }
 
 // NewKeyWrapper returns a new key wrapping interface using pkcs11


### PR DESCRIPTION
Bring the pkcs11 module out of the experimental stage. This will
now cause that any previously pkc11-encrypted images will not be
accessible anymore.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>