### PR TITLE
pkcs11: PCT-encode the keyid when displaying in error message

### DIFF
--- a/crypto/pkcs11/pkcs11helpers.go
+++ b/crypto/pkcs11/pkcs11helpers.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -230,7 +231,7 @@ func findObject(p11ctx *pkcs11.Ctx, session pkcs11.SessionHandle, class uint, ke
 		if len(msg) > 0 {
 			msg += " and "
 		}
-		msg += fmt.Sprintf("id '%s'", keyid)
+		msg += url.PathEscape(keyid)
 	}
 
 	if err := p11ctx.FindObjectsInit(session, template); err != nil {


### PR DESCRIPTION
Currently an error message displaying the key id may display binary
data. Since the keyid is typically PCT-encoded in the URI we should
display it in this format.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>