### PR TITLE
WIP: Add computation and verification of previous layers' hashes

### DIFF
--- a/blockcipher/blockcipher.go
+++ b/blockcipher/blockcipher.go
@@ -45,6 +45,9 @@ type PrivateLayerBlockCipherOptions struct {
 	// CipherOptions contains the cipher metadata used for encryption/decryption
 	// This field should be populated by Encrypt/Decrypt calls
 	CipherOptions map[string][]byte `json:"cipheroptions"`
+
+	// PreviousLayersDigest is the accumulated digest of all previous layers
+	PreviousLayersDigest digest.Digest `json:"previouslayersdigest"`
 }
 
 // PublicLayerBlockCipherOptions includes the information required to encrypt/decrypt

--- a/scripts/calc_next_previous_layers_digest
+++ b/scripts/calc_next_previous_layers_digest
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+
+echo "Enter PreviousLayersDigest or leave empty for initial one"
+read previousLayersDigest
+if [ -z "$previousLayersDigest" ]; then
+	previousLayersDigest=$(echo -en | sha256sum | gawk '{print $1}')
+fi
+if ! [[ $previousLayersDigest =~ ^[0-9a-fA-F]{64}$ ]]; then
+	echo "previousLayersDigest '$previousLayersDigest' must be a sha256"
+	exit 1
+fi
+while :; do
+	echo "Enter current layer's digest"
+	read currentLayerDigest
+	if ! [[ $currentLayerDigest =~ ^[0-9a-fA-F]{64}$ ]]; then
+		echo "current layer digest must be a sha256"
+		exit 1
+	fi
+
+	dig=$(echo -n "${previousLayersDigest}${currentLayerDigest}" |
+	      sed -n 's/[0-9a-fA-F]\{2\}/\\x\0/pg' )
+
+	previousLayersDigest=$(echo -en "${dig}" | sha256sum | gawk '{print $1}')
+	echo "digest: ${previousLayersDigest}"
+done

--- a/utils/hashes.go
+++ b/utils/hashes.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The ocicrypt Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+// GetInitalPreviousLayersDigest returns the initial value for previousLayersDigest
+func GetInitialPreviousLayersDigest() []byte {
+	digest := sha256.Sum256(nil)
+	return digest[:]
+}
+
+// GetNewLayersDigest calculates the new layer digest from the previousLayersDigest and the layerDigest.
+func GetNewLayersDigest(previousLayersDigest []byte, layerDigest digest.Digest) ([]byte, error) {
+	newDigest := sha256.New()
+	// never returns an error but linter requires us to look at it
+	_, err := newDigest.Write(previousLayersDigest)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, err := hex.DecodeString(layerDigest.Encoded())
+	if err != nil {
+		return nil, errors.Wrap(err, "Hex decoding digest failed")
+	}
+	_, err = newDigest.Write(digest)
+	return newDigest.Sum(nil), err
+}


### PR DESCRIPTION
This patch adds the computation of previous layers accumulated hashes
on the encryption side and writes this computed hash into the private
options of a layer. The private options will be encrypted then. On the
decryption side it also performs the computations and, if the private
options contain the previous layers' hash, which may not be the case for
older images but will be the case for newer ones, it compares the expected
hash against the computed one and errors if they don't match.

The previous layers' digest needs to be passed from one layer encrytion
step to the next. The sequence must begin with the bottom-most layer
getting sha256.Sum256(nil) passed so that no other layer can be slid
underneath the bottom-most one.

This patch at least helps fulfill the requirement that previous layers
cannot be manipulated assuming the attacker can access the registry but
of course not manipulate the decryption code.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>