### PR TITLE
go.mod: gopkg.in/yaml.v2 v2.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	golang.org/x/sys v0.0.0-20200817155316-9781c653f443 // indirect
 	google.golang.org/grpc v1.33.2
 	gopkg.in/square/go-jose.v2 v2.5.1
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -110,7 +110,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
gopkg.in/yaml.v2 v2.3.0 introduced a breaking change for Kubernetes, and should
not have gone into a "minor" release. Acknowledging this was a breaking change,
version v2.4.0 was released with this change reverted.

From the v2.4.0 release notes:

> It was clearly a mistake to accept the default formatting change in v2,
> and now there's no ideal choice. Either we revert the change and break
> some projects twice, or we keep the change and break some projects once.
> Given the report comes from Kubernetes, which has a relevant community
> and code size, we'll revert it. At the same time, to simplify the life
> of those that already started migrating towards the v3 behavior, a new
> FutureLineWrap function is being introduced to trivially preserve the
> new behavior where desired.
>
> The v3 branch is not affected by this, and will retain the default
> non-wrapping behavior. It will also be changed soon to support per
> arbitrary line-wrapping for individual encoding operations.
>
> Thanks to everyone who offered code and ideas, and apologies for
> the trouble.

While go modules will pick the "highest" version if both exist in the dependency
tree, such as in k8s, it's good to prevent any chance of the "broken" version
getting accidentally used, so this updates the version to v2.4.0.

full diff: https://github.com/go-yaml/yaml/compare/v2.3.0...v2.4.0
