### PR TITLE
Upgrade miekg/pkcs11 from v1.0.3 to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2 // indirect
-	github.com/miekg/pkcs11 v1.0.3
+	github.com/miekg/pkcs11 v1.1.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/miekg/pkcs11 v1.0.3 h1:iMwmD7I5225wv84WxIG/bmxz9AXjWvTWIbM/TYHvWtw=
-github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=


### PR DESCRIPTION
Currently, the containers/ocicrypt library does not build on OpenBSD:

```
$ go test .
# github.com/miekg/pkcs11
ld: error: unable to find library -ldl
cc: error: linker command failed with exit code 1 (use -v to see invocation)
FAIL	github.com/containers/ocicrypt [build failed]
FAIL
```

This PR upgrades the miekg/pkcs11 component to a version that compiles cleanly on OpenBSD. Here are the functional PR's included in the miekg/pkcs11 upgrade from v1.0.3:

* https://github.com/miekg/pkcs11/pull/124
* https://github.com/miekg/pkcs11/pull/133
* https://github.com/miekg/pkcs11/pull/137
* https://github.com/miekg/pkcs11/pull/140
* https://github.com/miekg/pkcs11/pull/143
* https://github.com/miekg/pkcs11/pull/150

For a more specific diff , see https://github.com/miekg/pkcs11/compare/v1.0.3...v1.1.1