### PR TITLE
Append Stderr to Key Provider Cmd Execution Errors

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -243,7 +243,7 @@ func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) 
 		}
 	}
 	if !privKeyGiven {
-		return nil, errors.New("missing private key needed for decryption")
+		return nil, errors.Errorf("missing private key needed for decryption:\n%s", errs)
 	}
 	return nil, errors.Errorf("no suitable key unwrapper found or none of the private keys could be used for decryption:\n%s", errs)
 }

--- a/utils/ioutils.go
+++ b/utils/ioutils.go
@@ -45,13 +45,15 @@ type Runner struct{}
 // ExecuteCommand is used to execute a linux command line command and return the output of the command with an error if it exists.
 func (r Runner) Exec(cmdName string, args []string, input []byte) ([]byte, error) {
 	var out bytes.Buffer
+	var stderr bytes.Buffer
 	stdInputBuffer := bytes.NewBuffer(input)
 	cmd := exec.Command(cmdName, args...)
 	cmd.Stdin = stdInputBuffer
 	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while running command: %s", cmdName)
+		return nil, errors.Wrapf(err, "Error while running command: %s. stderr: %s", cmdName, stderr.String())
 	}
 	return out.Bytes(), nil
 }


### PR DESCRIPTION
Add stderr to the Key Provider Cmd Execution errors for better visibility into failed executions.