### PR TITLE
Mimic Travis CI with Github Actions.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,38 @@
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.18' ]
+    name: Go Version ${{ matrix.go }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install deps
+      run: sudo apt-get install -y gnutls-bin softhsm2
+
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Install 
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+
+    - name: Build
+      run: make
+
+    - name: Run golangci-lint
+      run: make check
+
+    - name: Test
+      run: make test


### PR DESCRIPTION
Create basic `go.yml` workflow to mimic behaviour of Travis CI on Github Actions in order to address https://github.com/containers/ocicrypt/issues/50.
Actions for Golang version 1.16 and 1.18 are executed in parallel.

The resulting GH Actions for this can be found e.g https://github.com/BruegelN/ocicrypt/actions/runs/3629107980 .

There is a GH Action to run `golangci-lint` https://github.com/marketplace/actions/run-golangci-lint which would allow to combine the step of installing `golangci-lint` and running `make check`. An example can be found here:  https://github.com/BruegelN/ocicrypt/commit/bb146cc59cf3d9e52d985793c9c7818936ca9fc4 and the resulting Action https://github.com/BruegelN/ocicrypt/actions/runs/3629352644.
But I've decided to stick as closely to the current Travis CI as possible. Also running `make check` locally and the execution `golangci-lint` on CI are identical. What's your take on this? 

Are there other events that should trigger CI to run other than pushes and PRs against `main`? E.g. run CI on all pushes?
GH Actions has a bunch of triggers which would allow to run CI on external events or to ensure compatibility with third parties e.g a ways to schedule CI runs in a cron like manner https://docs.github.com/de/actions/using-workflows/events-that-trigger-workflows#schedule.

Please consider this as MWE and let me know if you have further suggestions/hints to improve :slightly_smiling_face: 


-----
Something I've noticed along the way: 
[Current `go.mod#L3`](https://github.com/containers/ocicrypt/blob/b0e73385d69b5b6e41373d64de45f11c89be026d/go.mod#L3) references `go 1.12` however CI builds with `go 1.16` and `go 1.18`.


