### PR TITLE
remove github.com/pkg/errors

### DIFF
--- a/blockcipher/blockcipher.go
+++ b/blockcipher/blockcipher.go
@@ -17,10 +17,11 @@
 package blockcipher
 
 import (
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 // LayerCipherType is the ciphertype as specified in the layer metadata
@@ -129,7 +130,7 @@ func (h *LayerBlockCipherHandler) Encrypt(plainDataReader io.Reader, typ LayerCi
 		}
 		return encDataReader, fin, err
 	}
-	return nil, nil, errors.Errorf("unsupported cipher type: %s", typ)
+	return nil, nil, fmt.Errorf("unsupported cipher type: %s", typ)
 }
 
 // Decrypt is the handler for the layer decryption routine
@@ -141,7 +142,7 @@ func (h *LayerBlockCipherHandler) Decrypt(encDataReader io.Reader, opt LayerBloc
 	if c, ok := h.cipherMap[typ]; ok {
 		return c.Decrypt(encDataReader, opt)
 	}
-	return nil, LayerBlockCipherOptions{}, errors.Errorf("unsupported cipher type: %s", typ)
+	return nil, LayerBlockCipherOptions{}, fmt.Errorf("unsupported cipher type: %s", typ)
 }
 
 // NewLayerBlockCipherHandler returns a new default handler
@@ -153,7 +154,7 @@ func NewLayerBlockCipherHandler() (*LayerBlockCipherHandler, error) {
 	var err error
 	h.cipherMap[AES256CTR], err = NewAESCTRLayerBlockCipher(256)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to set up Cipher AES-256-CTR")
+		return nil, fmt.Errorf("unable to set up Cipher AES-256-CTR: %w", err)
 	}
 
 	return &h, nil

--- a/blockcipher/blockcipher_aes_ctr.go
+++ b/blockcipher/blockcipher_aes_ctr.go
@@ -22,12 +22,12 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
 
 	"github.com/containers/ocicrypt/utils"
-	"github.com/pkg/errors"
 )
 
 // AESCTRLayerBlockCipher implements the AES CTR stream cipher
@@ -74,7 +74,7 @@ func (r *aesctrcryptor) Read(p []byte) (int, error) {
 
 	if !r.bc.encrypt {
 		if _, err := r.bc.hmac.Write(p[:o]); err != nil {
-			r.bc.err = errors.Wrapf(err, "could not write to hmac")
+			r.bc.err = fmt.Errorf("could not write to hmac: %w", err)
 			return 0, r.bc.err
 		}
 
@@ -92,7 +92,7 @@ func (r *aesctrcryptor) Read(p []byte) (int, error) {
 
 	if r.bc.encrypt {
 		if _, err := r.bc.hmac.Write(p[:o]); err != nil {
-			r.bc.err = errors.Wrapf(err, "could not write to hmac")
+			r.bc.err = fmt.Errorf("could not write to hmac: %w", err)
 			return 0, r.bc.err
 		}
 
@@ -120,13 +120,13 @@ func (bc *AESCTRLayerBlockCipher) init(encrypt bool, reader io.Reader, opts Laye
 	if !ok {
 		nonce = make([]byte, aes.BlockSize)
 		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-			return LayerBlockCipherOptions{}, errors.Wrap(err, "unable to generate random nonce")
+			return LayerBlockCipherOptions{}, fmt.Errorf("unable to generate random nonce: %w", err)
 		}
 	}
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return LayerBlockCipherOptions{}, errors.Wrap(err, "aes.NewCipher failed")
+		return LayerBlockCipherOptions{}, fmt.Errorf("aes.NewCipher failed: %w", err)
 	}
 
 	bc.reader = reader

--- a/config/constructors.go
+++ b/config/constructors.go
@@ -17,10 +17,11 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/containers/ocicrypt/crypto/pkcs11"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,7 +86,7 @@ func EncryptWithPkcs11(pkcs11Config *pkcs11.Pkcs11Config, pkcs11Pubkeys, pkcs11Y
 		}
 		p11confYaml, err := yaml.Marshal(pkcs11Config)
 		if err != nil {
-			return CryptoConfig{}, errors.Wrapf(err, "Could not marshal Pkcs11Config to Yaml")
+			return CryptoConfig{}, fmt.Errorf("Could not marshal Pkcs11Config to Yaml: %w", err)
 		}
 
 		dc = DecryptConfig{
@@ -223,7 +224,7 @@ func DecryptWithGpgPrivKeys(gpgPrivKeys, gpgPrivKeysPwds [][]byte) (CryptoConfig
 func DecryptWithPkcs11Yaml(pkcs11Config *pkcs11.Pkcs11Config, pkcs11Yamls [][]byte) (CryptoConfig, error) {
 	p11confYaml, err := yaml.Marshal(pkcs11Config)
 	if err != nil {
-		return CryptoConfig{}, errors.Wrapf(err, "Could not marshal Pkcs11Config to Yaml")
+		return CryptoConfig{}, fmt.Errorf("Could not marshal Pkcs11Config to Yaml: %w", err)
 	}
 
 	dc := DecryptConfig{

--- a/config/keyprovider-config/config.go
+++ b/config/keyprovider-config/config.go
@@ -18,9 +18,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // Command describes the structure of command, it consist of path and args, where path defines the location of
@@ -72,7 +71,7 @@ func GetConfiguration() (*OcicryptConfig, error) {
 	if len(filename) > 0 {
 		ic, err = parseConfigFile(filename)
 		if err != nil {
-			return nil, errors.Wrap(err, "Error while parsing keyprovider config file")
+			return nil, fmt.Errorf("Error while parsing keyprovider config file: %w", err)
 		}
 	} else {
 		return nil, nil

--- a/config/pkcs11config/config.go
+++ b/config/pkcs11config/config.go
@@ -17,12 +17,12 @@
 package pkcs11config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
 
 	"github.com/containers/ocicrypt/crypto/pkcs11"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 

--- a/crypto/pkcs11/common.go
+++ b/crypto/pkcs11/common.go
@@ -16,7 +16,6 @@ package pkcs11
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	pkcs11uri "github.com/stefanberger/go-pkcs11uri"
 	"gopkg.in/yaml.v3"
 )
@@ -43,7 +42,7 @@ func ParsePkcs11Uri(uri string) (*pkcs11uri.Pkcs11URI, error) {
 	p11uri := pkcs11uri.New()
 	err := p11uri.Parse(uri)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Could not parse Pkcs11URI from file")
+		return nil, fmt.Errorf("Could not parse Pkcs11URI from file: %w", err)
 	}
 	return p11uri, err
 }
@@ -58,7 +57,7 @@ func ParsePkcs11KeyFile(yamlstr []byte) (*Pkcs11KeyFileObject, error) {
 
 	err := yaml.Unmarshal(yamlstr, &p11keyfile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Could not unmarshal pkcs11 keyfile")
+		return nil, fmt.Errorf("Could not unmarshal pkcs11 keyfile: %w", err)
 	}
 
 	p11uri, err := ParsePkcs11Uri(p11keyfile.Pkcs11.Uri)
@@ -129,7 +128,7 @@ func ParsePkcs11ConfigFile(yamlstr []byte) (*Pkcs11Config, error) {
 
 	err := yaml.Unmarshal(yamlstr, &p11conf)
 	if err != nil {
-		return &p11conf, errors.Wrapf(err, "Could not parse Pkcs11Config")
+		return &p11conf, fmt.Errorf("Could not parse Pkcs11Config: %w", err)
 	}
 	return &p11conf, nil
 }

--- a/crypto/pkcs11/pkcs11helpers_nocgo.go
+++ b/crypto/pkcs11/pkcs11helpers_nocgo.go
@@ -1,3 +1,4 @@
+//go:build !cgo
 // +build !cgo
 
 /*
@@ -18,14 +19,12 @@
 
 package pkcs11
 
-import (
-	"github.com/pkg/errors"
-)
+import "fmt"
 
 func EncryptMultiple(pubKeys []interface{}, data []byte) ([]byte, error) {
-	return nil, errors.Errorf("ocicrypt pkcs11 not supported on this build")
+	return nil, fmt.Errorf("ocicrypt pkcs11 not supported on this build")
 }
 
 func Decrypt(privKeyObjs []*Pkcs11KeyFileObject, pkcs11blobstr []byte) ([]byte, error) {
-	return nil, errors.Errorf("ocicrypt pkcs11 not supported on this build")
+	return nil, fmt.Errorf("ocicrypt pkcs11 not supported on this build")
 }

--- a/crypto/pkcs11/utils.go
+++ b/crypto/pkcs11/utils.go
@@ -17,12 +17,11 @@
 package pkcs11
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -45,7 +44,7 @@ func setEnvVars(env map[string]string) ([]string, error) {
 		err := os.Setenv(k, v)
 		if err != nil {
 			restoreEnv(oldenv)
-			return nil, errors.Wrapf(err, "Could not set environment variable '%s' to '%s'", k, v)
+			return nil, fmt.Errorf("Could not set environment variable '%s' to '%s': %w", k, v, err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/gpg.go
+++ b/gpg.go
@@ -17,6 +17,7 @@
 package ocicrypt
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/term"
 )
 
@@ -132,7 +132,7 @@ func (gc *gpgv2Client) GetGPGPrivateKey(keyid uint64, passphrase string) ([]byte
 
 	rfile, wfile, err := os.Pipe()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not create pipe")
+		return nil, fmt.Errorf("could not create pipe: %w", err)
 	}
 	defer func() {
 		rfile.Close()
@@ -352,7 +352,7 @@ func GPGGetPrivateKey(descs []ocispec.Descriptor, gpgClient GPGClient, gpgVault 
 			}
 			keywrapper := GetKeyWrapper(scheme)
 			if keywrapper == nil {
-				return nil, nil, errors.Errorf("could not get KeyWrapper for %s", scheme)
+				return nil, nil, fmt.Errorf("could not get KeyWrapper for %s", scheme)
 			}
 			keyIds, err := keywrapper.GetKeyIdsFromPacket(b64pgpPackets)
 			if err != nil {
@@ -411,7 +411,7 @@ func GPGGetPrivateKey(descs []ocispec.Descriptor, gpgClient GPGClient, gpgVault 
 			if !found && len(b64pgpPackets) > 0 && mustFindKey {
 				ids := uint64ToStringArray("0x%x", keyIds)
 
-				return nil, nil, errors.Errorf("missing key for decryption of layer %x of %s. Need one of the following keys: %s", desc.Digest, desc.Platform, strings.Join(ids, ", "))
+				return nil, nil, fmt.Errorf("missing key for decryption of layer %x of %s. Need one of the following keys: %s", desc.Digest, desc.Platform, strings.Join(ids, ", "))
 			}
 		}
 	}

--- a/gpgvault.go
+++ b/gpgvault.go
@@ -18,9 +18,9 @@ package ocicrypt
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/packet"
 )
@@ -55,7 +55,7 @@ func (g *gpgVault) AddSecretKeyRingData(gpgSecretKeyRingData []byte) error {
 	r := bytes.NewReader(gpgSecretKeyRingData)
 	entityList, err := openpgp.ReadKeyRing(r)
 	if err != nil {
-		return errors.Wrapf(err, "could not read keyring")
+		return fmt.Errorf("could not read keyring: %w", err)
 	}
 	g.entityLists = append(g.entityLists, entityList)
 	g.keyDataList = append(g.keyDataList, gpgSecretKeyRingData)

--- a/keywrap/jwe/keywrapper_jwe.go
+++ b/keywrap/jwe/keywrapper_jwe.go
@@ -18,11 +18,12 @@ package jwe
 
 import (
 	"crypto/ecdsa"
+	"errors"
+	"fmt"
 
 	"github.com/containers/ocicrypt/config"
 	"github.com/containers/ocicrypt/keywrap"
 	"github.com/containers/ocicrypt/utils"
-	"github.com/pkg/errors"
 	jose "gopkg.in/square/go-jose.v2"
 )
 
@@ -54,11 +55,11 @@ func (kw *jweKeyWrapper) WrapKeys(ec *config.EncryptConfig, optsData []byte) ([]
 
 	encrypter, err := jose.NewMultiEncrypter(jose.A256GCM, joseRecipients, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "jose.NewMultiEncrypter failed")
+		return nil, fmt.Errorf("jose.NewMultiEncrypter failed: %w", err)
 	}
 	jwe, err := encrypter.Encrypt(optsData)
 	if err != nil {
-		return nil, errors.Wrapf(err, "JWE Encrypt failed")
+		return nil, fmt.Errorf("JWE Encrypt failed: %w", err)
 	}
 	return []byte(jwe.FullSerialize()), nil
 }

--- a/keywrap/pkcs11/keywrapper_pkcs11.go
+++ b/keywrap/pkcs11/keywrapper_pkcs11.go
@@ -17,12 +17,13 @@
 package pkcs11
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/containers/ocicrypt/config"
 	"github.com/containers/ocicrypt/crypto/pkcs11"
 	"github.com/containers/ocicrypt/keywrap"
 	"github.com/containers/ocicrypt/utils"
-
-	"github.com/pkg/errors"
 )
 
 type pkcs11KeyWrapper struct {
@@ -51,7 +52,7 @@ func (kw *pkcs11KeyWrapper) WrapKeys(ec *config.EncryptConfig, optsData []byte) 
 
 	jsonString, err := pkcs11.EncryptMultiple(pkcs11Recipients, optsData)
 	if err != nil {
-		return nil, errors.Wrapf(err, "PKCS11 EncryptMulitple failed")
+		return nil, fmt.Errorf("PKCS11 EncryptMulitple failed: %w", err)
 	}
 	return jsonString, nil
 }
@@ -91,7 +92,7 @@ func (kw *pkcs11KeyWrapper) UnwrapKey(dc *config.DecryptConfig, jsonString []byt
 		return plaintext, nil
 	}
 
-	return nil, errors.Wrapf(err, "PKCS11: No suitable private key found for decryption")
+	return nil, fmt.Errorf("PKCS11: No suitable private key found for decryption: %w", err)
 }
 
 func (kw *pkcs11KeyWrapper) NoPossibleKeys(dcparameters map[string][][]byte) bool {

--- a/keywrap/pkcs7/keywrapper_pkcs7.go
+++ b/keywrap/pkcs7/keywrapper_pkcs7.go
@@ -19,11 +19,12 @@ package pkcs7
 import (
 	"crypto"
 	"crypto/x509"
+	"errors"
+	"fmt"
 
 	"github.com/containers/ocicrypt/config"
 	"github.com/containers/ocicrypt/keywrap"
 	"github.com/containers/ocicrypt/utils"
-	"github.com/pkg/errors"
 	"go.mozilla.org/pkcs7"
 )
 
@@ -104,7 +105,7 @@ func (kw *pkcs7KeyWrapper) UnwrapKey(dc *config.DecryptConfig, pkcs7Packet []byt
 
 	p7, err := pkcs7.Parse(pkcs7Packet)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not parse PKCS7 packet")
+		return nil, fmt.Errorf("could not parse PKCS7 packet: %w", err)
 	}
 
 	for idx, privKey := range privKeys {

--- a/utils/ioutils.go
+++ b/utils/ioutils.go
@@ -18,10 +18,9 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
-
-	"github.com/pkg/errors"
 )
 
 // FillBuffer fills the given buffer with as many bytes from the reader as possible. It returns
@@ -53,7 +52,7 @@ func (r Runner) Exec(cmdName string, args []string, input []byte) ([]byte, error
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while running command: %s. stderr: %s", cmdName, stderr.String())
+		return nil, fmt.Errorf("Error while running command: %s. stderr: %s: %w", cmdName, stderr.String(), err)
 	}
 	return out.Bytes(), nil
 }

--- a/utils/softhsm/softhsm.go
+++ b/utils/softhsm/softhsm.go
@@ -18,11 +18,11 @@ package softhsm
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type SoftHSMSetup struct {
@@ -43,7 +43,7 @@ func (s *SoftHSMSetup) GetConfigFilename() string {
 func (s *SoftHSMSetup) RunSoftHSMSetup(softhsmSetup string) (string, error) {
 	statedir, err := os.MkdirTemp("", "ocicrypt")
 	if err != nil {
-		return "", errors.Wrapf(err, "Could not create temporary directory fot softhsm state")
+		return "", fmt.Errorf("Could not create temporary directory fot softhsm state: %w", err)
 	}
 	s.statedir = statedir
 
@@ -54,7 +54,7 @@ func (s *SoftHSMSetup) RunSoftHSMSetup(softhsmSetup string) (string, error) {
 	err = cmd.Run()
 	if err != nil {
 		os.RemoveAll(s.statedir)
-		return "", errors.Wrapf(err, "%s setup failed: %s", softhsmSetup, out.String())
+		return "", fmt.Errorf("%s setup failed: %s: %w", softhsmSetup, out.String(), err)
 	}
 
 	o := out.String()
@@ -75,7 +75,7 @@ func (s *SoftHSMSetup) RunSoftHSMGetPubkey(softhsmSetup string) (string, error) 
 	cmd.Env = append(cmd.Env, "SOFTHSM_SETUP_CONFIGDIR="+s.statedir)
 	err := cmd.Run()
 	if err != nil {
-		return "", errors.Wrapf(err, "%s getpubkey failed: %s", softhsmSetup, out.String())
+		return "", fmt.Errorf("%s getpubkey failed: %s: %w", softhsmSetup, out.String(), err)
 	}
 
 	return out.String(), nil

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -24,17 +24,16 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // CreateRSAKey creates an RSA key
 func CreateRSAKey(bits int) (*rsa.PrivateKey, error) {
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
-		return nil, errors.Wrap(err, "rsa.GenerateKey failed")
+		return nil, fmt.Errorf("rsa.GenerateKey failed: %w", err)
 	}
 	return key, nil
 }
@@ -49,7 +48,7 @@ func CreateRSATestKey(bits int, password []byte, pemencode bool) ([]byte, []byte
 
 	pubData, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "x509.MarshalPKIXPublicKey failed")
+		return nil, nil, fmt.Errorf("x509.MarshalPKIXPublicKey failed: %w", err)
 	}
 	privData := x509.MarshalPKCS1PrivateKey(key)
 
@@ -69,7 +68,7 @@ func CreateRSATestKey(bits int, password []byte, pemencode bool) ([]byte, []byte
 	if len(password) > 0 {
 		block, err = x509.EncryptPEMBlock(rand.Reader, typ, privData, password, x509.PEMCipherAES256) //nolint:staticcheck // ignore SA1019, which is kept for backward compatibility
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "x509.EncryptPEMBlock failed")
+			return nil, nil, fmt.Errorf("x509.EncryptPEMBlock failed: %w", err)
 		}
 	} else {
 		block = &pem.Block{
@@ -88,17 +87,17 @@ func CreateRSATestKey(bits int, password []byte, pemencode bool) ([]byte, []byte
 func CreateECDSATestKey(curve elliptic.Curve) ([]byte, []byte, error) {
 	key, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "ecdsa.GenerateKey failed")
+		return nil, nil, fmt.Errorf("ecdsa.GenerateKey failed: %w", err)
 	}
 
 	pubData, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "x509.MarshalPKIXPublicKey failed")
+		return nil, nil, fmt.Errorf("x509.MarshalPKIXPublicKey failed: %w", err)
 	}
 
 	privData, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "x509.MarshalECPrivateKey failed")
+		return nil, nil, fmt.Errorf("x509.MarshalECPrivateKey failed: %w", err)
 	}
 
 	return pubData, privData, nil
@@ -108,7 +107,7 @@ func CreateECDSATestKey(curve elliptic.Curve) ([]byte, []byte, error) {
 func CreateTestCA() (*rsa.PrivateKey, *x509.Certificate, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "rsa.GenerateKey failed")
+		return nil, nil, fmt.Errorf("rsa.GenerateKey failed: %w", err)
 	}
 
 	ca := &x509.Certificate{
@@ -154,12 +153,12 @@ func certifyKey(pub interface{}, template *x509.Certificate, caKey *rsa.PrivateK
 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, pub, caKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "x509.CreateCertificate failed")
+		return nil, fmt.Errorf("x509.CreateCertificate failed: %w", err)
 	}
 
 	cert, err := x509.ParseCertificate(certDER)
 	if err != nil {
-		return nil, errors.Wrap(err, "x509.ParseCertificate failed")
+		return nil, fmt.Errorf("x509.ParseCertificate failed: %w", err)
 	}
 
 	return cert, nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,12 +21,12 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containers/ocicrypt/crypto/pkcs11"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
 	json "gopkg.in/square/go-jose.v2"
 )
@@ -36,7 +36,7 @@ func parseJWKPrivateKey(privKey []byte, prefix string) (interface{}, error) {
 	jwk := json.JSONWebKey{}
 	err := jwk.UnmarshalJSON(privKey)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s: Could not parse input as JWK", prefix)
+		return nil, fmt.Errorf("%s: Could not parse input as JWK: %w", prefix, err)
 	}
 	if jwk.IsPublic() {
 		return nil, fmt.Errorf("%s: JWK is not a private key", prefix)
@@ -49,7 +49,7 @@ func parseJWKPublicKey(privKey []byte, prefix string) (interface{}, error) {
 	jwk := json.JSONWebKey{}
 	err := jwk.UnmarshalJSON(privKey)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s: Could not parse input as JWK", prefix)
+		return nil, fmt.Errorf("%s: Could not parse input as JWK: %w", prefix, err)
 	}
 	if !jwk.IsPublic() {
 		return nil, fmt.Errorf("%s: JWK is not a public key", prefix)
@@ -97,11 +97,11 @@ func ParsePrivateKey(privKey, privKeyPassword []byte, prefix string) (interface{
 			var der []byte
 			if x509.IsEncryptedPEMBlock(block) { //nolint:staticcheck // ignore SA1019, which is kept for backward compatibility
 				if privKeyPassword == nil {
-					return nil, errors.Errorf("%s: Missing password for encrypted private key", prefix)
+					return nil, fmt.Errorf("%s: Missing password for encrypted private key", prefix)
 				}
 				der, err = x509.DecryptPEMBlock(block, privKeyPassword) //nolint:staticcheck // ignore SA1019, which is kept for backward compatibility
 				if err != nil {
-					return nil, errors.Errorf("%s: Wrong password: could not decrypt private key", prefix)
+					return nil, fmt.Errorf("%s: Wrong password: could not decrypt private key", prefix)
 				}
 			} else {
 				der = block.Bytes
@@ -111,7 +111,7 @@ func ParsePrivateKey(privKey, privKeyPassword []byte, prefix string) (interface{
 			if err != nil {
 				key, err = x509.ParsePKCS1PrivateKey(der)
 				if err != nil {
-					return nil, errors.Wrapf(err, "%s: Could not parse private key", prefix)
+					return nil, fmt.Errorf("%s: Could not parse private key: %w", prefix, err)
 				}
 			}
 		} else {
@@ -145,7 +145,7 @@ func ParsePublicKey(pubKey []byte, prefix string) (interface{}, error) {
 		if block != nil {
 			key, err = x509.ParsePKIXPublicKey(block.Bytes)
 			if err != nil {
-				return nil, errors.Wrapf(err, "%s: Could not parse public key", prefix)
+				return nil, fmt.Errorf("%s: Could not parse public key: %w", prefix, err)
 			}
 		} else {
 			key, err = parseJWKPublicKey(pubKey, prefix)
@@ -179,7 +179,7 @@ func ParseCertificate(certBytes []byte, prefix string) (*x509.Certificate, error
 		}
 		x509Cert, err = x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s: Could not parse x509 certificate", prefix)
+			return nil, fmt.Errorf("%s: Could not parse x509 certificate: %w", prefix, err)
 		}
 	}
 	return x509Cert, err


### PR DESCRIPTION
[pkg/errors](https://github.com/pkg/errors) has been archived and we use `fmt.Errorf` to replace `errors.Wrap`/`errors.Wrapf`