### PR TITLE
Do not preallocate regex in init program

### DIFF
--- a/gpg.go
+++ b/gpg.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -310,9 +311,15 @@ func resolveRecipients(gc GPGClient, recipients []string) []string {
 	return result
 }
 
-var emailPattern = regexp.MustCompile(`uid\s+\[.*\]\s.*\s<(?P<email>.+)>`)
+var (
+	onceRegexp   sync.Once
+	emailPattern *regexp.Regexp
+)
 
 func extractEmailFromDetails(details []byte) string {
+	onceRegexp.Do(func() {
+		emailPattern = regexp.MustCompile(`uid\s+\[.*\]\s.*\s<(?P<email>.+)>`)
+	})
 	loc := emailPattern.FindSubmatchIndex(details)
 	if len(loc) == 0 {
 		return ""


### PR DESCRIPTION
We are trying to speed up the startup of container applications by not MustCompiling in init but waiting until first use of application.

While this will only speed up start by a couple of microseconds, the more we get rid of the faster the apps will start.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>