### PR TITLE
jwe: Support overriding the algorithm when supplying a JWK

### DIFF
--- a/keywrap/jwe/keywrapper_jwe.go
+++ b/keywrap/jwe/keywrapper_jwe.go
@@ -123,9 +123,24 @@ func addPubKeys(joseRecipients *[]jose.Recipient, pubKeys [][]byte) error {
 		}
 
 		alg := jose.RSA_OAEP
-		switch key.(type) {
+		switch key := key.(type) {
 		case *ecdsa.PublicKey:
 			alg = jose.ECDH_ES_A256KW
+		case *jose.JSONWebKey:
+			if key.Algorithm != "" {
+				alg = jose.KeyAlgorithm(key.Algorithm)
+				switch alg {
+				/* accepted algorithms */
+				case jose.RSA_OAEP:
+				case jose.RSA_OAEP_256:
+				case jose.ECDH_ES_A128KW:
+				case jose.ECDH_ES_A192KW:
+				case jose.ECDH_ES_A256KW:
+				/* all others are rejected */
+				default:
+					return fmt.Errorf("%s is an unsupported JWE key algorithm", alg)
+				}
+			}
 		}
 
 		*joseRecipients = append(*joseRecipients, jose.Recipient{

--- a/keywrap/jwe/keywrapper_jwe_test.go
+++ b/keywrap/jwe/keywrapper_jwe_test.go
@@ -70,6 +70,21 @@ func createValidJweCcs() ([]*config.CryptoConfig, error) {
 		return nil, err
 	}
 
+	ecKey, err := utils.CreateECDSAKey(elliptic.P521())
+	if err != nil {
+		return nil, err
+	}
+
+	jweEcPrivKeyJwk, err := jose.JSONWebKey{Key: ecKey, Algorithm: string(jose.ECDH_ES_A256KW)}.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	jweEcPubKeyJwk, err := jose.JSONWebKey{Key: &ecKey.PublicKey, Algorithm: string(jose.ECDH_ES_A256KW)}.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
 	validJweCcs := []*config.CryptoConfig{
 		// Key 1
 		{
@@ -222,6 +237,27 @@ func createValidJweCcs() ([]*config.CryptoConfig, error) {
 			DecryptConfig: &config.DecryptConfig{
 				Parameters: map[string][][]byte{
 					"privkeys":           {jweEcPrivKeyDer},
+					"privkeys-passwords": {oneEmpty},
+				},
+			},
+		},
+		// EC Key (JWK format)
+		{
+			EncryptConfig: &config.EncryptConfig{
+				Parameters: map[string][][]byte{
+					"pubkeys": {jweEcPubKeyJwk},
+				},
+				DecryptConfig: config.DecryptConfig{
+					Parameters: map[string][][]byte{
+						"privkeys":           {jweEcPrivKeyJwk},
+						"privkeys-passwords": {oneEmpty},
+					},
+				},
+			},
+
+			DecryptConfig: &config.DecryptConfig{
+				Parameters: map[string][][]byte{
+					"privkeys":           {jweEcPrivKeyJwk},
 					"privkeys-passwords": {oneEmpty},
 				},
 			},

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -38,6 +38,15 @@ func CreateRSAKey(bits int) (*rsa.PrivateKey, error) {
 	return key, nil
 }
 
+// CreateECDSAKey creates an elliptic curve key for the given curve
+func CreateECDSAKey(curve elliptic.Curve) (*ecdsa.PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("ecdsa.GenerateKey failed: %w", err)
+	}
+	return key, nil
+}
+
 // CreateRSATestKey creates an RSA key of the given size and returns
 // the public and private key in PEM or DER format
 func CreateRSATestKey(bits int, password []byte, pemencode bool) ([]byte, []byte, error) {
@@ -85,9 +94,9 @@ func CreateRSATestKey(bits int, password []byte, pemencode bool) ([]byte, []byte
 // CreateECDSATestKey creates and elliptic curve key for the given curve and returns
 // the public and private key in DER format
 func CreateECDSATestKey(curve elliptic.Curve) ([]byte, []byte, error) {
-	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	key, err := CreateECDSAKey(curve)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ecdsa.GenerateKey failed: %w", err)
+		return nil, nil, err
 	}
 
 	pubData, err := x509.MarshalPKIXPublicKey(&key.PublicKey)


### PR DESCRIPTION
Otherwise, the current code makes it impossible to supply a JWK-encoded ECDSA public key in the encryption config. (`ParsePublicKey` returns `parseJWKPublicKey` which returns the JWK itself; hence the switch-case fails to notice the ECDSA key inside the JWK)

The code in `keywrapper_jwe.go` finding the right value for `alg` could probably be structured better; something such as the following pseudocode might capture intent better:
```
if key is JWK:
  if JWK has algorithm set:
    use the algorithm from the JWK 
  else:
    continue with JWK.key
if key is RSA:
  use RSA_OAEP
else if key is ECDA:
  use ECDH_ES_A256KW
else:
  report error
```

Or well, for the purposes of the issue I was facing, just having the initial `if key is JWK: continue with JWK.key`, without allowing for customizing the algorithm, would also be sufficient.