### PR TITLE
Update go versions and golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: Install
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.1
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
 
     - name: Build
       run: make

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.21', '1.20' ]
+        go: [ '1.22', '1.21' ]
     name: Go Version ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - goimports
     - revive
     - ineffassign
-    - vet
+    - govet
     - unused
     - misspell
 

--- a/blockcipher/blockcipher.go
+++ b/blockcipher/blockcipher.go
@@ -96,9 +96,8 @@ func (lbco LayerBlockCipherOptions) GetOpt(key string) (value []byte, ok bool) {
 		return v, ok
 	} else if v, ok := lbco.Private.CipherOptions[key]; ok {
 		return v, ok
-	} else {
-		return nil, false
 	}
+	return nil, false
 }
 
 func wrapFinalizerWithType(fin Finalizer, typ LayerCipherType) Finalizer {

--- a/gpg.go
+++ b/gpg.go
@@ -79,9 +79,8 @@ func GuessGPGVersion() GPGVersion {
 		return GPGv2
 	} else if err := exec.Command("gpg", "--version").Run(); err == nil {
 		return GPGv1
-	} else {
-		return GPGVersionUndetermined
 	}
+	return GPGVersionUndetermined
 }
 
 // NewGPGClient creates a new GPGClient object representing the given version

--- a/keywrap/keyprovider/keyprovider.go
+++ b/keywrap/keyprovider/keyprovider.go
@@ -124,9 +124,8 @@ func (kw *keyProviderKeyWrapper) WrapKeys(ec *config.EncryptConfig, optsData []b
 			}
 
 			return protocolOuput.KeyWrapResults.Annotation, nil
-		} else {
-			return nil, errors.New("Unsupported keyprovider invocation. Supported invocation methods are grpc and cmd")
 		}
+		return nil, errors.New("Unsupported keyprovider invocation. Supported invocation methods are grpc and cmd")
 	}
 
 	return nil, nil
@@ -162,9 +161,8 @@ func (kw *keyProviderKeyWrapper) UnwrapKey(dc *config.DecryptConfig, jsonString 
 		}
 
 		return protocolOuput.KeyUnwrapResults.OptsData, nil
-	} else {
-		return nil, errors.New("Unsupported keyprovider invocation. Supported invocation methods are grpc and cmd")
 	}
+	return nil, errors.New("Unsupported keyprovider invocation. Supported invocation methods are grpc and cmd")
 }
 
 func getProviderGRPCOutput(input []byte, connString string, operation KeyProviderKeyWrapProtocolOperation) (*KeyProviderKeyWrapProtocolOutput, error) {


### PR DESCRIPTION
Update to go 1.22 and 1.21 and golangci-lint 1.59.1