### PR TITLE
feat: add WASM encrypted layer media type support

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -42,6 +42,8 @@ import (
 // the encrypted layer
 type EncryptLayerFinalizer func() (map[string]string, error)
 
+const keyProviderSchemePrefix = "provider."
+
 func init() {
 	keyWrappers = make(map[string]keywrap.KeyWrapper)
 	keyWrapperAnnotations = make(map[string]string)
@@ -54,7 +56,7 @@ func init() {
 		log.Error(err)
 	} else if ic != nil {
 		for provider, attrs := range ic.KeyProviderConfig {
-			RegisterKeyWrapper("provider."+provider, keyprovider.NewKeyWrapper(provider, attrs))
+			RegisterKeyWrapper(keyProviderSchemePrefix+provider, keyprovider.NewKeyWrapper(provider, attrs))
 		}
 	}
 }
@@ -227,7 +229,7 @@ func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) 
 				continue
 			}
 
-			isKeyprovider := strings.HasPrefix(scheme, "provider.")
+			isKeyprovider := strings.HasPrefix(scheme, keyProviderSchemePrefix)
 			if isKeyprovider {
 				keyproviderTried = true
 			}

--- a/encryption.go
+++ b/encryption.go
@@ -213,6 +213,7 @@ func DecryptLayer(dc *config.DecryptConfig, encLayerReader io.Reader, desc ocisp
 
 func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) ([]byte, error) {
 	privKeyGiven := false
+	keyproviderTried := false
 	errs := ""
 	if len(keyWrapperAnnotations) == 0 {
 		return nil, errors.New("missing Annotations needed for decryption")
@@ -224,6 +225,11 @@ func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) 
 
 			if keywrapper.NoPossibleKeys(dc.Parameters) {
 				continue
+			}
+
+			isKeyprovider := strings.HasPrefix(scheme, "provider.")
+			if isKeyprovider {
+				keyproviderTried = true
 			}
 
 			if len(keywrapper.GetPrivateKeys(dc.Parameters)) > 0 {
@@ -242,7 +248,7 @@ func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) 
 			return optsData, nil
 		}
 	}
-	if !privKeyGiven {
+	if !privKeyGiven && !keyproviderTried {
 		return nil, fmt.Errorf("missing private key needed for decryption:\n%s", errs)
 	}
 	return nil, fmt.Errorf("no suitable key unwrapper found or none of the private keys could be used for decryption:\n%s", errs)

--- a/encryption_test.go
+++ b/encryption_test.go
@@ -141,3 +141,55 @@ func TestEncryptLayer(t *testing.T) {
 		t.Fatalf("Expected %v, got %v", data, decLayer)
 	}
 }
+
+func TestWasmMediaTypeEncryption(t *testing.T) {
+	data := []byte("This is WASM module data!")
+	desc := ocispec.Descriptor{
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+		MediaType: "application/vnd.wasm.content.layer.v1+wasm",
+	}
+
+	dataReader := bytes.NewReader(data)
+
+	encLayerReader, encLayerFinalizer, err := EncryptLayer(ec, dataReader, desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encLayer := make([]byte, 1024)
+	encsize, err := encLayerReader.Read(encLayer)
+	if err != io.EOF {
+		t.Fatal("Expected EOF")
+	}
+	encLayerReaderAt := bytes.NewReader(encLayer[:encsize])
+
+	annotations, err := encLayerFinalizer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(annotations) == 0 {
+		t.Fatal("No keys created for annotations")
+	}
+
+	newDesc := ocispec.Descriptor{
+		Annotations: annotations,
+		MediaType:   "application/vnd.wasm.content.layer.v1+wasm+encrypted",
+	}
+
+	decLayerReader, _, err := DecryptLayer(dc, encLayerReaderAt, newDesc, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decLayer := make([]byte, 1024)
+	decsize, err := decLayerReader.Read(decLayer)
+	if err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(decLayer[:decsize], data) {
+		t.Fatalf("Expected %v, got %v", data, decLayer)
+	}
+}

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -17,6 +17,8 @@ const (
 	//
 	// Deprecated: Use [MediaTypeLayerNonDistributableZstdEnc].
 	MediaTypeLayerNonDistributableZsdtEnc = MediaTypeLayerNonDistributableZstdEnc
+	// MediaTypeWasmLayer is MIME type used for WASM layers.
+	MediaTypeWasmLayer = "application/vnd.wasm.content.layer.v1+wasm"
 	// MediaTypeWasmEnc is MIME type used for encrypted WASM layers.
-	MediaTypeWasmEnc = "application/vnd.wasm.content.layer.v1+wasm+encrypted"
+	MediaTypeWasmEnc = MediaTypeWasmLayer + "+encrypted"
 )

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -17,4 +17,6 @@ const (
 	//
 	// Deprecated: Use [MediaTypeLayerNonDistributableZstdEnc].
 	MediaTypeLayerNonDistributableZsdtEnc = MediaTypeLayerNonDistributableZstdEnc
+	// MediaTypeWasmEnc is MIME type used for encrypted WASM layers.
+	MediaTypeWasmEnc = "application/vnd.wasm.content.layer.v1+wasm+encrypted"
 )


### PR DESCRIPTION
## Description

Add support for encrypting and decrypting WASM layer media types and improve key provider handling during decryption.

### New Features
- Support encrypted WASM layer media type via a new spec constant and descriptor usage.

### Tests:
- Add an encryption/decryption round-trip test for WASM layer media types to validate the new support.
