### PR TITLE
Replace golang.org/x/crypto/openpgp with github.com/ProtonMail/go-crypto/openpgp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/containers/ocicrypt
 go 1.25.0
 
 require (
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/miekg/pkcs11 v1.1.2
 	github.com/opencontainers/go-digest v1.0.0
@@ -12,15 +13,16 @@ require (
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v3 v3.0.4
-	golang.org/x/crypto v0.53.0
 	golang.org/x/term v0.44.0
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
+	github.com/cloudflare/circl v1.6.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
+github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cloudflare/circl v1.6.2 h1:hL7VBpHHKzrV5WTfHCaBsgx/HGbBYlgrwvNXEVDYYsQ=
+github.com/cloudflare/circl v1.6.2/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/gpgvault.go
+++ b/gpgvault.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 // GPGVault defines an interface for wrapping multiple secret key rings

--- a/keywrap/pgp/keywrapper_gpg.go
+++ b/keywrap/pgp/keywrapper_gpg.go
@@ -28,10 +28,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/containers/ocicrypt/config"
 	"github.com/containers/ocicrypt/keywrap"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
 )
 
 type gpgKeyWrapper struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -25,11 +25,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/containers/ocicrypt/config/pkcs11config"
 	"github.com/containers/ocicrypt/crypto/pkcs11"
 	"github.com/go-jose/go-jose/v4"
 	"go.yaml.in/yaml/v3"
-	"golang.org/x/crypto/openpgp"
 )
 
 // parseJWKPrivateKey parses the input byte array as a JWK and makes sure it's a private key


### PR DESCRIPTION
`x/crypto/openpgp` now contains a stronger deprecation warning:
> ```
> // Deprecated: this package is unsafe by design, and has numerous known security
> // issues. It is not maintained, and should not be used.
> ```

and points at github.com/ProtonMail/go-crypto/openpgp , so use that one.