### PR TITLE
Add WASM media types and encryption test

### DIFF
--- a/encryption_test.go
+++ b/encryption_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/containers/ocicrypt/config"
+	"github.com/containers/ocicrypt/spec"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -124,6 +125,62 @@ func TestEncryptLayer(t *testing.T) {
 
 	newDesc := ocispec.Descriptor{
 		Annotations: annotations,
+	}
+
+	decLayerReader, _, err := DecryptLayer(dc, encLayerReaderAt, newDesc, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decLayer := make([]byte, 1024)
+	decsize, err := decLayerReader.Read(decLayer)
+	if err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(decLayer[:decsize], data) {
+		t.Fatalf("Expected %v, got %v", data, decLayer)
+	}
+}
+
+func TestWasmMediaTypeEncryption(t *testing.T) {
+	if spec.MediaTypeWasmEnc != spec.MediaTypeWasmLayer+"+encrypted" {
+		t.Fatalf("Expected encrypted WASM media type %q, got %q", spec.MediaTypeWasmLayer+"+encrypted", spec.MediaTypeWasmEnc)
+	}
+
+	data := []byte("This is WASM module data!")
+	desc := ocispec.Descriptor{
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+		MediaType: spec.MediaTypeWasmLayer,
+	}
+
+	dataReader := bytes.NewReader(data)
+
+	encLayerReader, encLayerFinalizer, err := EncryptLayer(ec, dataReader, desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encLayer := make([]byte, 1024)
+	encsize, err := encLayerReader.Read(encLayer)
+	if err != io.EOF {
+		t.Fatal("Expected EOF")
+	}
+	encLayerReaderAt := bytes.NewReader(encLayer[:encsize])
+
+	annotations, err := encLayerFinalizer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(annotations) == 0 {
+		t.Fatal("No keys created for annotations")
+	}
+
+	newDesc := ocispec.Descriptor{
+		Annotations: annotations,
+		MediaType:   spec.MediaTypeWasmEnc,
 	}
 
 	decLayerReader, _, err := DecryptLayer(dc, encLayerReaderAt, newDesc, false)

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -17,4 +17,8 @@ const (
 	//
 	// Deprecated: Use [MediaTypeLayerNonDistributableZstdEnc].
 	MediaTypeLayerNonDistributableZsdtEnc = MediaTypeLayerNonDistributableZstdEnc
+	// MediaTypeWasmLayer is MIME type used for WASM layers.
+	MediaTypeWasmLayer = "application/vnd.wasm.content.layer.v1+wasm"
+	// MediaTypeWasmEnc is MIME type used for encrypted WASM layers.
+	MediaTypeWasmEnc = MediaTypeWasmLayer + "+encrypted"
 )


### PR DESCRIPTION
## What does this PR do?

Adds the WASM layer media types to the spec so encrypted WASM layers can be recognised by ocicrypt consumers.

No changes to the encryption or keywrapper logic — the pipeline is media-type agnostic.

Related: 

- https://github.com/containers/ocicrypt/pull/126
- https://github.com/confidential-containers/guest-components/pull/1271

